### PR TITLE
Move compat into its own folder and add examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,25 +73,27 @@ sbot.db.query(
 ```
 
 SSB DB2 includes a couple of plugins for backwards compatibility,
-including legacy replication, ebt and publish. The can be loaded as:
+including legacy replication, ebt and publish. They can be loaded as:
 
 ```js
 const SecretStack = require('secret-stack')
 
 const sbot = SecretStack({appKey: caps.shs})
   .use(require('ssb-db2'))
-  .use(require('ssb-db2/compat')) // include all compat plugins
+  .use(require('ssb-db2/compat')) // include all compatibility plugins
   .call(null, {})
 ```
 
-or specifically
+or specifically:
 
 ```js
 const SecretStack = require('secret-stack')
 
 const sbot = SecretStack({appKey: caps.shs})
   .use(require('ssb-db2'))
-  .use(require('ssb-db2/compat/db')) // only db compatibility
+  .use(require('ssb-db2/compat/db')) // basic db compatibility
+  .use(require('ssb-db2/compat/history-histream')) // legacy replication
+  .use(require('ssb-db2/compat/ebt')) // ebt db helpers
   .call(null, {})
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const SecretStack = require('secret-stack')
 const sbot = SecretStack({appKey: caps.shs})
   .use(require('ssb-db2'))
   .use(require('ssb-db2/compat/db')) // basic db compatibility
-  .use(require('ssb-db2/compat/history-histream')) // legacy replication
+  .use(require('ssb-db2/compat/history-stream')) // legacy replication
   .use(require('ssb-db2/compat/ebt')) // ebt db helpers
   .call(null, {})
 ```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ sbot.db.query(
 )
 ```
 
+SSB DB2 includes a couple of plugins for backwards compatibility,
+including legacy replication, ebt and publish. The can be loaded as:
+
+```js
+const SecretStack = require('secret-stack')
+
+const sbot = SecretStack({appKey: caps.shs})
+  .use(require('ssb-db2'))
+  .use(require('ssb-db2/compat')) // include all compat plugins
+  .call(null, {})
+```
+
+or specifically
+
+```js
+const SecretStack = require('secret-stack')
+
+const sbot = SecretStack({appKey: caps.shs})
+  .use(require('ssb-db2'))
+  .use(require('ssb-db2/compat/db')) // only db compatibility
+  .call(null, {})
+```
+
 ## Methods
 
 FIXME: add documentation for these

--- a/compat/db.js
+++ b/compat/db.js
@@ -1,0 +1,3 @@
+exports.init = function (sbot, config) {
+  sbot.publish = sbot.db.publish
+}

--- a/compat/ebt.js
+++ b/compat/ebt.js
@@ -1,7 +1,4 @@
 exports.init = function (sbot, config) {
-  sbot.publish = sbot.db.publish
-
-  // EBT
   sbot.post = sbot.db.post
   sbot.getAtSequence = sbot.db.getMessageFromAuthorSequence
   sbot.getVectorClock = function(cb) {

--- a/compat/history-stream.js
+++ b/compat/history-stream.js
@@ -1,8 +1,8 @@
 const pull = require('pull-stream')
 const pullCont = require('pull-cont')
 const ref = require('ssb-ref')
-const { originalData } = require('./msg-utils')
-const { author } = require("./operators")
+const { originalData } = require('../msg-utils')
+const { author } = require("../operators")
 
 // exports.name is blank to merge into global namespace
 

--- a/compat/index.js
+++ b/compat/index.js
@@ -1,0 +1,9 @@
+const db = require("./db")
+const ebt = require("./ebt")
+const hist = require("./history-stream")
+
+exports.init = function (sbot, config) {
+  db.init(sbot, config)
+  ebt.init(sbot, config)
+  hist.init(sbot, config)
+}

--- a/test/createHistoryStream.js
+++ b/test/createHistoryStream.js
@@ -20,7 +20,7 @@ const db = DB.init(dir, {
 
 // simulate secret stack
 let sbot = {db}
-require("../replicate-compat").init(sbot)
+require("../compat/history-stream").init(sbot)
 
 test('Base', t => {
   const post = { type: 'post', text: 'Testing!' }


### PR DESCRIPTION
Makes compat a bit cleaner