### PR TITLE
migration plugin for ssb-db=>ssb-db2

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,46 @@ const sbot = SecretStack({appKey: caps.shs})
   .call(null, {})
 ```
 
+## Migrating from ssb-db
+
+The flumelog used underneath ssb-db2 is different than that one in ssb-db, this means we need to scan over the old log and copy all messages onto the new log, if you wish to use ssb-db2 to make queries.
+
+ssb-db2 comes with migration methods built-in, you can enable them (they are off by default!) in your config file (or object):
+
+```js
+const SecretStack = require('secret-stack')
+
+const config = {
+  keys: keys,
+  db2: {
+    automigrate: true
+  }
+}
+
+const sbot = SecretStack({appKey: caps.shs})
+  .use(require('ssb-db2'))
+  .use(require('ssb-db2/compat'))
+  .call(null, config)
+```
+
+The above script will initiate migration as soon as the plugins are loaded. If you wish the manually dictate when the migration starts, don't use the `automigrate` config above, instead, call the `migrate.start()` method yourself:
+
+```js
+sbot.db.migrate.start()
+```
+
+Note, it is acceptable to load both ssb-db and ssb-db2 plugins, the system will still function correctly and migrate correctly:
+
+```js
+const sbot = SecretStack({appKey: caps.shs})
+  .use(require('ssb-db'))
+  .use(require('ssb-db2'))
+  .use(require('ssb-db2/compat'))
+  .call(null, config)
+```
+
+However, note that while the old log exists, it will be continously migrated to the new log, and ssb-db2 forbids you to use its database-writing APIs such as `add()`, `publish()`, `del()` and so forth, to prevent the two logs from diverging into inconsistent states. The old log will remain the source of truth and keep getting copied into the new log, until the old log file does not exist anymore.
+
 ## Methods
 
 FIXME: add documentation for these

--- a/db.js
+++ b/db.js
@@ -10,7 +10,7 @@ const JITDb = require('jitdb')
 
 const Log = require('./log')
 const BaseIndex = require('./indexes/base')
-const Migration = require('./migration')
+const Migrate = require('./migrate')
 const Partial = require('./indexes/partial')
 
 function getId(msg) {
@@ -21,7 +21,7 @@ exports.init = function (sbot, dir, config) {
   const log = Log(dir, config)
   const jitdb = JITDb(log, path.join(dir, 'db2', 'indexes'))
   const baseIndex = BaseIndex(log, dir, config.keys.public)
-  const migration = Migration.init(sbot, config, log)
+  const migrate = Migrate.init(sbot, config, log)
   //const contacts = fullIndex.contacts
   //const partial = Partial(dir)
 
@@ -47,7 +47,7 @@ exports.init = function (sbot, dir, config) {
   })
 
   function guardAgainstDuplicateLogs(methodName) {
-    if (migration.oldLogExists.value === true) {
+    if (migrate.oldLogExists.value === true) {
       return new Error(
         'ssb-db2: refusing to ' +
           methodName +
@@ -339,7 +339,7 @@ exports.init = function (sbot, dir, config) {
     getLatest: baseIndex.getLatest,
     getAllLatest: baseIndex.getAllLatest,
     getMessageFromAuthorSequence: baseIndex.getMessageFromAuthorSequence,
-    migration,
+    migrate,
 
     // FIXME: contacts & profiles
 

--- a/db.js
+++ b/db.js
@@ -10,16 +10,18 @@ const JITDb = require('jitdb')
 
 const Log = require('./log')
 const BaseIndex = require('./indexes/base')
+const Migration = require('./migration')
 const Partial = require('./indexes/partial')
 
 function getId(msg) {
   return '%' + hash(JSON.stringify(msg, null, 2))
 }
 
-exports.init = function (dir, config) {
+exports.init = function (sbot, dir, config) {
   const log = Log(dir, config)
   const jitdb = JITDb(log, path.join(dir, 'db2', 'indexes'))
   const baseIndex = BaseIndex(log, dir, config.keys.public)
+  const migration = Migration.init(sbot, config, log)
   //const contacts = fullIndex.contacts
   //const partial = Partial(dir)
 
@@ -44,6 +46,18 @@ exports.init = function (dir, config) {
     }
   })
 
+  function guardAgainstDuplicateLogs(methodName) {
+    if (migration.oldLogExists.value === true) {
+      return new Error(
+        'ssb-db2: refusing to ' +
+          methodName +
+          ' because the old log still exists. ' +
+          'This is to protect your feed from forking ' +
+          'into an irrecoverable state.'
+      )
+    }
+  }
+
   function get(id, cb) {
     baseIndex.getMessageFromKey(id, (err, data) => {
       if (data) cb(null, data.value)
@@ -52,6 +66,9 @@ exports.init = function (dir, config) {
   }
 
   function add(msg, cb) {
+    const guard = guardAgainstDuplicateLogs('add()')
+    if (guard) return cb(guard)
+
     const id = getId(msg)
 
     /*
@@ -89,6 +106,9 @@ exports.init = function (dir, config) {
   }
 
   function publish(msg, cb) {
+    const guard = guardAgainstDuplicateLogs('publish()')
+    if (guard) return cb(guard)
+
     state.queue = []
     state = validate.appendNew(state, null, config.keys, msg, Date.now())
     add(state.queue[0].value, (err, data) => {
@@ -98,6 +118,9 @@ exports.init = function (dir, config) {
   }
 
   function del(key, cb) {
+    const guard = guardAgainstDuplicateLogs('del()')
+    if (guard) return cb(guard)
+
     baseIndex.keyToSeq(key, (err, seq) => {
       if (err) return cb(err)
       if (seq == null) return cb(new Error('seq is null!'))
@@ -107,6 +130,9 @@ exports.init = function (dir, config) {
   }
 
   function deleteFeed(feedId, cb) {
+    const guard = guardAgainstDuplicateLogs('deleteFeed()')
+    if (guard) return cb(guard)
+
     // FIXME: doesn't work, need test
     jitdb.onReady(() => {
       jitdb.query(
@@ -142,6 +168,9 @@ exports.init = function (dir, config) {
   }
 
   function validateAndAddOOO(msg, cb) {
+    const guard = guardAgainstDuplicateLogs('validateAndAddOOO()')
+    if (guard) return cb(guard)
+
     try {
       let oooState = validate.initial()
       validate.appendOOO(oooState, hmac_key, msg)
@@ -155,6 +184,9 @@ exports.init = function (dir, config) {
   }
 
   function validateAndAdd(msg, cb) {
+    const guard = guardAgainstDuplicateLogs('validateAndAdd()')
+    if (guard) return cb(guard)
+
     const knownAuthor = msg.author in state.feeds
 
     try {
@@ -303,11 +335,11 @@ exports.init = function (dir, config) {
 
     registerIndex,
     indexes,
-    log,
 
     getLatest: baseIndex.getLatest,
     getAllLatest: baseIndex.getAllLatest,
     getMessageFromAuthorSequence: baseIndex.getMessageFromAuthorSequence,
+    migration,
 
     // FIXME: contacts & profiles
 

--- a/db.js
+++ b/db.js
@@ -303,6 +303,7 @@ exports.init = function (dir, config) {
 
     registerIndex,
     indexes,
+    log,
 
     getLatest: baseIndex.getLatest,
     getAllLatest: baseIndex.getAllLatest,

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const DB = require('./db')
 exports.name = 'db'
 
 exports.init = function (sbot, config) {
-  const db = DB.init(config.path, config)
+  const db = DB.init(sbot, config.path, config)
   sbot.close.hook(function (fn, args) {
     db.close()
     return fn.apply(this, args)

--- a/index.js
+++ b/index.js
@@ -5,8 +5,9 @@ exports.name = 'db'
 exports.init = function (sbot, config) {
   const db = DB.init(sbot, config.path, config)
   sbot.close.hook(function (fn, args) {
-    db.close()
-    return fn.apply(this, args)
+    db.close(() => {
+      fn.apply(this, args)
+    })
   })
   return db
 }

--- a/migrate.js
+++ b/migrate.js
@@ -181,5 +181,6 @@ exports.init = function init(sbot, config, newLog) {
   return {
     start,
     oldLogExists,
+    // dangerouslyKillOldLog, // FIXME: implement this
   }
 }

--- a/migrate.js
+++ b/migrate.js
@@ -101,6 +101,7 @@ exports.init = function init(sbot, config, newLog) {
 
     let oldSize = null
     let migratedSize = null
+    let progressCalls = 0
 
     function updateOldSize(read) {
       read(null, function next(end, data) {
@@ -122,8 +123,10 @@ exports.init = function init(sbot, config, newLog) {
 
     function emitProgressEvent() {
       if (oldSize !== null && migratedSize !== null) {
-        const progress = migratedSize / oldSize
-        sbot.emit('ssb:db2:migrate:progress', progress)
+        if (progressCalls++ % 1000 == 0) {
+          const progress = migratedSize / oldSize
+          sbot.emit('ssb:db2:migrate:progress', progress)
+        }
       }
     }
 

--- a/migrate.js
+++ b/migrate.js
@@ -123,7 +123,7 @@ exports.init = function init(sbot, config, newLog) {
 
     function emitProgressEvent() {
       if (oldSize !== null && migratedSize !== null) {
-        if (progressCalls++ % 1000 == 0) {
+        if (progressCalls < 100 || progressCalls++ % 1000 == 0) {
           const progress = migratedSize / oldSize
           sbot.emit('ssb:db2:migrate:progress', progress)
         }
@@ -149,7 +149,6 @@ exports.init = function init(sbot, config, newLog) {
       if (err) return console.error(err)
       if (msgCountNewLog === 0) debug('new log is empty, will start migrating')
       else debug('new log has %s msgs, will continue migrating', msgCountNewLog)
-
       pull(
         oldLogStream,
         skip(msgCountNewLog, function whenDoneSkipping(obj) {

--- a/migrate.js
+++ b/migrate.js
@@ -6,7 +6,7 @@ const FlumeLog = require('flumelog-offset')
 const bipf = require('bipf')
 const jsonCodec = require('flumecodec/json')
 const Obv = require('obv')
-const debug = require('debug')('ssb:db2:migration')
+const debug = require('debug')('ssb:db2:migrate')
 
 const blockSize = 64 * 1024
 
@@ -123,7 +123,7 @@ exports.init = function init(sbot, config, newLog) {
     function emitProgressEvent() {
       if (oldSize !== null && migratedSize !== null) {
         const progress = migratedSize / oldSize
-        sbot.emit('ssb:db2:migration:progress', progress)
+        sbot.emit('ssb:db2:migrate:progress', progress)
       }
     }
 

--- a/migration.js
+++ b/migration.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const pull = require('pull-stream')
+const Notify = require('pull-notify')
 const FlumeLog = require('flumelog-offset')
 const bipf = require('bipf')
 const jsonCodec = require('flumecodec/json')
@@ -7,28 +8,40 @@ const debug = require('debug')('ssb:db2:migration')
 
 const blockSize = 64 * 1024
 
-function skip(count) {
+function skip(count, onDone) {
   let skipped = 0
-  return pull.filter(() => {
+  return pull.filter((x) => {
     if (skipped >= count) return true
     else {
       skipped++
+      if (skipped === count && onDone) onDone(x)
       return false
     }
   })
 }
 
-function getOldLogStream(sbot, config, live) {
+function getOldLogStreams(sbot, config, live) {
   const old = !live
-  if (sbot.createRawLogStream) {
-    return pull(
-      sbot.createRawLogStream({ old, live }),
-      pull.map((obj) => obj.value)
+  if (sbot.createRawLogStream && sbot.createSequenceStream) {
+    const logStream = sbot.createRawLogStream({ old, live })
+    if (live) return [logStream]
+    const sizeStream = pull(
+      sbot.createSequenceStream(),
+      pull.filter((x) => x >= 0)
     )
+    return [logStream, sizeStream]
   } else {
     const oldLogPath = path.join(config.path, 'flume', 'log.offset')
     const oldLog = FlumeLog(oldLogPath, { blockSize, codec: jsonCodec })
-    return pull(oldLog.stream({ seqs: false, old, live, codec: jsonCodec }))
+    const logStream = oldLog.stream({ seqs: true, old, live, codec: jsonCodec })
+    if (live) return [logStream]
+    const notify = Notify()
+    oldLog.since(notify)
+    const sizeStream = pull(
+      notify.listen(),
+      pull.filter((x) => x >= 0)
+    )
+    return [logStream, sizeStream]
   }
 }
 
@@ -55,9 +68,37 @@ function scanAndCount(pushstream, cb) {
 }
 
 exports.init = function init(sbot, config) {
-  const oldLogStream = getOldLogStream(sbot, config, false)
-  const oldLogStreamLive = getOldLogStream(sbot, config, true)
+  const [oldLogStream, oldSizeStream] = getOldLogStreams(sbot, config, false)
+  const [oldLogStreamLive] = getOldLogStreams(sbot, config, true)
   const newLogStream = sbot.db.log.stream({ gte: 0 })
+
+  let oldSize = null
+  let migratedSize = null
+
+  function updateOldSize(read) {
+    read(null, function next(end, data) {
+      if (end === true) return
+      if (end) throw end
+      oldSize = data
+      read(null, next)
+    })
+  }
+
+  function updateMigratedSize(obj) {
+    migratedSize = obj.seq
+  }
+
+  function updateMigratedSizeAndPluck(obj) {
+    updateMigratedSize(obj)
+    return obj.value
+  }
+
+  function emitProgressEvent() {
+    if (oldSize !== null && migratedSize !== null) {
+      const progress = migratedSize / oldSize
+      sbot.emit('ssb:db2:migration:progress', progress)
+    }
+  }
 
   let dataTransferred = 0 // FIXME: does this only work if the new log is empty?
   function writeTo(log) {
@@ -66,18 +107,26 @@ exports.init = function init(sbot, config) {
       // FIXME: could we use log.add since it already converts to BIPF?
       // FIXME: see also issue #16
       log.append(data, () => {})
+      emitProgressEvent()
       if (dataTransferred % blockSize == 0) log.onDrain(cb)
       else cb()
     }
   }
 
+  updateOldSize(oldSizeStream)
+
   scanAndCount(newLogStream, (err, msgCountNewLog) => {
+    if (err) return console.error(err)
     if (msgCountNewLog === 0) debug('new log is empty, will start migrating')
     else debug('new log has %s msgs, will continue migrating', msgCountNewLog)
 
     pull(
       oldLogStream,
-      skip(msgCountNewLog),
+      skip(msgCountNewLog, function whenDoneSkipping(obj) {
+        updateMigratedSize(obj)
+        emitProgressEvent()
+      }),
+      pull.map(updateMigratedSizeAndPluck),
       pull.map(toBIPF),
       pull.asyncMap(writeTo(sbot.db.log)),
       pull.reduce(
@@ -89,6 +138,7 @@ exports.init = function init(sbot, config) {
 
           pull(
             oldLogStreamLive,
+            pull.map(updateMigratedSizeAndPluck),
             pull.map(toBIPF),
             pull.asyncMap(writeTo(sbot.db.log)),
             pull.drain(() => {

--- a/migration.js
+++ b/migration.js
@@ -79,9 +79,7 @@ function scanAndCount(pushstream, cb) {
   })
 }
 
-exports.name = 'dbMigration'
-
-exports.init = function init(sbot, config) {
+exports.init = function init(sbot, config, newLog) {
   const oldLogExists = makeFileExistsObv(getOldLogPath(config))
 
   let started = false
@@ -99,7 +97,7 @@ exports.init = function init(sbot, config) {
       sbot,
       config
     )
-    const newLogStream = sbot.db.log.stream({ gte: 0 })
+    const newLogStream = newLog.stream({ gte: 0 })
 
     let oldSize = null
     let migratedSize = null
@@ -157,7 +155,7 @@ exports.init = function init(sbot, config) {
         }),
         pull.map(updateMigratedSizeAndPluck),
         pull.map(toBIPF),
-        pull.asyncMap(writeTo(sbot.db.log)),
+        pull.asyncMap(writeTo(newLog)),
         pull.reduce(
           (x) => x + 1,
           0,
@@ -169,7 +167,7 @@ exports.init = function init(sbot, config) {
               oldLogStreamLive,
               pull.map(updateMigratedSizeAndPluck),
               pull.map(toBIPF),
-              pull.asyncMap(writeTo(sbot.db.log)),
+              pull.asyncMap(writeTo(newLog)),
               pull.drain(() => {
                 debug('1 new msg synced from old log to new log')
               })

--- a/migration.js
+++ b/migration.js
@@ -1,49 +1,102 @@
-const path = require('path');
-const pull = require('pull-stream');
-const FlumeLog = require('flumelog-offset');
-const AsyncFlumeLog = require('async-flumelog');
-const bipf = require('bipf');
-const jsonCodec = require('flumecodec/json');
-const debug = require('debug')('ssb:db2:migration');
+const path = require('path')
+const pull = require('pull-stream')
+const FlumeLog = require('flumelog-offset')
+const bipf = require('bipf')
+const jsonCodec = require('flumecodec/json')
+const debug = require('debug')('ssb:db2:migration')
 
-const blockSize = 64 * 1024;
+const blockSize = 64 * 1024
 
-exports.init = function (_sbot, config) {
-  const oldLogPath = path.join(config.path, 'flume', 'log.offset');
-  const newLogPath = path.join(config.path, 'db2', 'log.bipf');
+function skip(count) {
+  let skipped = 0
+  return pull.filter(() => {
+    if (skipped >= count) return true
+    else {
+      skipped++
+      return false
+    }
+  })
+}
 
-  const oldLog = FlumeLog(oldLogPath, {blockSize, codec: jsonCodec});
-  const newLog = AsyncFlumeLog(newLogPath, {blockSize});
+function getOldLogStream(sbot, config, live) {
+  const old = !live
+  if (sbot.createRawLogStream) {
+    return pull(
+      sbot.createRawLogStream({ old, live }),
+      pull.map((obj) => obj.value)
+    )
+  } else {
+    const oldLogPath = path.join(config.path, 'flume', 'log.offset')
+    const oldLog = FlumeLog(oldLogPath, { blockSize, codec: jsonCodec })
+    return pull(oldLog.stream({ seqs: false, old, live, codec: jsonCodec }))
+  }
+}
 
-  let dataTransferred = 0;
+function toBIPF(msg) {
+  const len = bipf.encodingLength(msg)
+  const buf = Buffer.alloc(len)
+  bipf.encode(msg, buf, 0)
+  return buf
+}
 
-  pull(
-    oldLog.stream({seqs: false, codec: jsonCodec}),
-    // oldLog.stream({seqs: false, live: true, codec: jsonCodec}), // FIXME: live
-    pull.map(function (data) {
-      const len = bipf.encodingLength(data);
-      const buf = Buffer.alloc(len);
-      bipf.encode(data, buf, 0);
-      return buf;
-    }),
-    function sink(read) {
-      read(null, function next(err, data) {
-        if (err && err !== true) throw err;
-        if (err) {
-          debug('done');
-          if (config._db2migrationCB) newLog.onDrain(() => {
-            newLog.close(config._db2migrationCB)
-          })
-          return
-        }
-        dataTransferred += data.length;
-        newLog.append(data, () => {});
-        if (dataTransferred % blockSize == 0)
-          newLog.onDrain(function () {
-            read(null, next);
-          });
-        else read(null, next);
-      });
+function scanAndCount(pushstream, cb) {
+  let count = 0
+  pushstream.pipe({
+    paused: false,
+    write: () => {
+      count += 1
     },
-  );
-};
+    end: function (err) {
+      if (this.ended) return
+      this.ended = err || true
+      cb(null, count)
+    },
+  })
+}
+
+exports.init = function init(sbot, config) {
+  const oldLogStream = getOldLogStream(sbot, config, false)
+  const oldLogStreamLive = getOldLogStream(sbot, config, true)
+  const newLogStream = sbot.db.log.stream({ gte: 0 })
+
+  let dataTransferred = 0 // FIXME: does this only work if the new log is empty?
+  function writeTo(log) {
+    return (data, cb) => {
+      dataTransferred += data.length
+      // FIXME: could we use log.add since it already converts to BIPF?
+      // FIXME: see also issue #16
+      log.append(data, () => {})
+      if (dataTransferred % blockSize == 0) log.onDrain(cb)
+      else cb()
+    }
+  }
+
+  scanAndCount(newLogStream, (err, msgCountNewLog) => {
+    if (msgCountNewLog === 0) debug('new log is empty, will start migrating')
+    else debug('new log has %s msgs, will continue migrating', msgCountNewLog)
+
+    pull(
+      oldLogStream,
+      skip(msgCountNewLog),
+      pull.map(toBIPF),
+      pull.asyncMap(writeTo(sbot.db.log)),
+      pull.reduce(
+        (x) => x + 1,
+        0,
+        (err, msgCountOldLog) => {
+          if (err) return console.error(err)
+          debug('done migrating %s msgs from old log', msgCountOldLog)
+
+          pull(
+            oldLogStreamLive,
+            pull.map(toBIPF),
+            pull.asyncMap(writeTo(sbot.db.log)),
+            pull.drain(() => {
+              debug('1 new msg synced from old log to new log')
+            })
+          )
+        }
+      )
+    )
+  })
+}

--- a/migration.js
+++ b/migration.js
@@ -84,12 +84,16 @@ exports.name = 'dbMigration'
 exports.init = function init(sbot, config) {
   const oldLogExists = makeFileExistsObv(getOldLogPath(config))
 
+  let started = false
+
   if (config.db2 && config.db2.automigrate) {
     start()
   }
 
   function start() {
     if (oldLogExists.value === false) return
+    if (started) return
+    started = true
 
     const [oldLogStream, oldLogStreamLive, oldSizeStream] = getOldLogStreams(
       sbot,

--- a/migration.js
+++ b/migration.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const pull = require('pull-stream');
+const FlumeLog = require('flumelog-offset');
+const AsyncFlumeLog = require('async-flumelog');
+const bipf = require('bipf');
+const jsonCodec = require('flumecodec/json');
+const debug = require('debug')('ssb:db2:migration');
+
+const blockSize = 64 * 1024;
+
+exports.init = function (_sbot, config) {
+  const oldLogPath = path.join(config.path, 'flume', 'log.offset');
+  const newLogPath = path.join(config.path, 'db2', 'log.bipf');
+
+  const oldLog = FlumeLog(oldLogPath, {blockSize, codec: jsonCodec});
+  const newLog = AsyncFlumeLog(newLogPath, {blockSize});
+
+  let dataTransferred = 0;
+
+  pull(
+    oldLog.stream({seqs: false, codec: jsonCodec}),
+    // oldLog.stream({seqs: false, live: true, codec: jsonCodec}), // FIXME: live
+    pull.map(function (data) {
+      const len = bipf.encodingLength(data);
+      const buf = Buffer.alloc(len);
+      bipf.encode(data, buf, 0);
+      return buf;
+    }),
+    function sink(read) {
+      read(null, function next(err, data) {
+        if (err && err !== true) throw err;
+        if (err) {
+          debug('done');
+          if (config._db2migrationCB) newLog.onDrain(() => {
+            newLog.close(config._db2migrationCB)
+          })
+          return
+        }
+        dataTransferred += data.length;
+        newLog.append(data, () => {});
+        if (dataTransferred % blockSize == 0)
+          newLog.onDrain(function () {
+            read(null, next);
+          });
+        else read(null, next);
+      });
+    },
+  );
+};

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "promisify-4loc": "1.0.0",
     "pull-cont": "^0.1.1",
     "pull-level": "^2.0.4",
+    "pull-notify": "~0.1.1",
     "pull-stream": "^3.6.14",
     "push-stream": "^11.0.0",
     "ssb-keys": "^8.0.0",
@@ -37,6 +38,7 @@
     "ssb-fixtures": "2.2.0",
     "ssb-db": "20.3.0",
     "secret-stack": "6.3.1",
+    "pull-stream-util": "0.1.2",
     "ssb-caps": "1.1.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "async-flumelog": "^1.0.8",
     "atomic-file": "^2.1.1",
     "bipf": "^1.3.0",
+    "debug": "~4.2.0",
+    "flumecodec": "0.0.1",
+    "flumelog-offset": "3.4.4",
     "husky": "^4.3.0",
     "jitdb": "~0.17.0",
     "level": "^6.0.1",
@@ -31,6 +34,10 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
+    "ssb-fixtures": "2.2.0",
+    "ssb-db": "20.3.0",
+    "secret-stack": "6.3.1",
+    "ssb-caps": "1.1.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     }
   },
   "author": "Anders Rune Jensen <arj03@protonmail.ch>",
-  "contributors": ["Andre Staltz <contact@staltz.com>"],
+  "contributors": [
+    "Andre Staltz <contact@staltz.com>"
+  ],
   "license": "LGPL-3.0"
 }

--- a/test/base-index.js
+++ b/test/base-index.js
@@ -16,7 +16,7 @@ mkdirp.sync(dir)
 
 const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
-const db = DB.init(dir, {
+const db = DB.init({}, dir, {
   path: dir,
   keys,
 })

--- a/test/createHistoryStream.js
+++ b/test/createHistoryStream.js
@@ -14,7 +14,7 @@ rimraf.sync(dir)
 mkdirp.sync(dir)
 
 const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
-const db = DB.init(dir, {
+const db = DB.init({}, dir, {
   path: dir,
   keys,
 })

--- a/test/migration.js
+++ b/test/migration.js
@@ -1,98 +1,95 @@
-const test = require('tape');
-const ssbKeys = require('ssb-keys');
-const path = require('path');
-const rimraf = require('rimraf');
-const mkdirp = require('mkdirp');
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
 const SecretStack = require('secret-stack')
 const caps = require('ssb-caps')
-const generateFixture = require('ssb-fixtures');
-const fs = require('fs');
-const DB = require('../db');
-const migration = require('../migration');
-const {toCallback} = require('../operators')
+const generateFixture = require('ssb-fixtures')
+const fs = require('fs')
+const { toCallback } = require('../operators')
 
-const dir = '/tmp/ssb-db2-migration';
+const dir = '/tmp/ssb-db2-migration'
 
-rimraf.sync(dir);
-mkdirp.sync(dir);
-
-let keys;
-let db;
+rimraf.sync(dir)
+mkdirp.sync(dir)
 
 test('generate fixture with flumelog-offset', (t) => {
   generateFixture({
     outputDir: dir,
     seed: 'migration',
-    messages: 100,
+    messages: 2,
     authors: 5,
     slim: true,
   }).then(() => {
     t.true(
       fs.existsSync(path.join(dir, 'flume', 'log.offset')),
-      'log.offset was created',
-    );
-    t.end();
-  });
-});
-
-test('migration creates ~/.ssb/flumelog.bipf', (t) => {
-  const config = {
-    path: dir,
-    _db2migrationCB: () => {
-      t.true(
-        fs.existsSync(path.join(dir, 'db2', 'log.bipf')),
-        'migration done',
-      );
-      t.end();
-    },
-  };
-  migration.init(null, config);
-});
-
-test('migrated db can be used with ssb-db2 APIs', (t) => {
-  keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
-  db = DB.init(dir, {
-    path: dir,
-    keys
-  })
-  t.equals(typeof db.jitdb, 'object')
-  db.onDrain(() => {
-    db.query(
-      toCallback((err1, msgs) => {
-        t.error(err1, 'no err')
-        t.equal(msgs.length, 100)
-        t.end()
-      })
+      'log.offset was created'
     )
+    t.end()
   })
 })
 
-// FIXME:
-test.skip('migrated db stays up-to-date as the old log is updated', (t) => {
-  db.onDrain(() => {
-    db.query(
-      toCallback((err1, msgs) => {
-        t.error(err1, 'no err')
-        t.equal(msgs.length, 100)
+test('migration moves msgs from old log to new log', (t) => {
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../index'))
+    .use(require('../migration'))
+    .call(null, { keys, path: dir })
 
-        const sbot = SecretStack({appKey: caps.shs})
-          .use(require('ssb-db'))
-          .call(null, {keys, path: dir})
-        sbot.publish({ type: 'post', text: 'Extra post' }, (err2, posted) => {
-          t.error(err2, 'no err')
-          t.equals(posted.value.content.type, 'post')
-
-          db.onDrain(() => {
-            db.query(
-              toCallback((err3, msgs2) => {
-                t.error(err3, 'no err')
-                t.equal(msgs2.length, 101)
-                t.end()
-              })
-            )
+  // FIXME: replace setTimeout with migration progress events
+  setTimeout(() => {
+    t.true(fs.existsSync(path.join(dir, 'db2', 'log.bipf')), 'migration done')
+    sbot.db.onDrain(() => {
+      sbot.db.query(
+        toCallback((err1, msgs) => {
+          t.error(err1, 'no err')
+          t.equal(msgs.length, 2)
+          sbot.close(() => {
+            t.end()
           })
         })
-      })
-    )
-  })
+      )
+    })
+  }, 1000)
+})
+
+test('migration keeps new log synced with old log being updated', (t) => {
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('ssb-db'))
+    .use(require('../index'))
+    .use(require('../migration'))
+    .call(null, { keys, path: dir })
+
+  // FIXME: replace setTimeout with migration progress events
+  setTimeout(() => {
+    t.true(fs.existsSync(path.join(dir, 'db2', 'log.bipf')), 'migration done')
+    sbot.db.onDrain(() => {
+      sbot.db.query(
+        toCallback((err1, msgs) => {
+          t.error(err1, '1st query suceeded')
+          t.equal(msgs.length, 2, '2 msgs')
+
+          sbot.publish({ type: 'post', text: 'Extra post' }, (err2, posted) => {
+            t.error(err2, 'publish suceeded')
+            t.equals(posted.value.content.type, 'post', 'msg posted')
+
+            // FIXME: replace setTimeout with migration progress events
+            setTimeout(() => {
+              sbot.db.query(
+                toCallback((err3, msgs2) => {
+                  t.error(err3, '2nd query suceeded')
+                  t.equal(msgs2.length, 3, '3 msgs')
+                  sbot.close(() => {
+                    t.end()
+                  })
+                })
+              )
+            }, 1000)
+          })
+        })
+      )
+    })
+  }, 1000)
 })

--- a/test/migration.js
+++ b/test/migration.js
@@ -1,0 +1,98 @@
+const test = require('tape');
+const ssbKeys = require('ssb-keys');
+const path = require('path');
+const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+const generateFixture = require('ssb-fixtures');
+const fs = require('fs');
+const DB = require('../db');
+const migration = require('../migration');
+const {toCallback} = require('../operators')
+
+const dir = '/tmp/ssb-db2-migration';
+
+rimraf.sync(dir);
+mkdirp.sync(dir);
+
+let keys;
+let db;
+
+test('generate fixture with flumelog-offset', (t) => {
+  generateFixture({
+    outputDir: dir,
+    seed: 'migration',
+    messages: 100,
+    authors: 5,
+    slim: true,
+  }).then(() => {
+    t.true(
+      fs.existsSync(path.join(dir, 'flume', 'log.offset')),
+      'log.offset was created',
+    );
+    t.end();
+  });
+});
+
+test('migration creates ~/.ssb/flumelog.bipf', (t) => {
+  const config = {
+    path: dir,
+    _db2migrationCB: () => {
+      t.true(
+        fs.existsSync(path.join(dir, 'db2', 'log.bipf')),
+        'migration done',
+      );
+      t.end();
+    },
+  };
+  migration.init(null, config);
+});
+
+test('migrated db can be used with ssb-db2 APIs', (t) => {
+  keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  db = DB.init(dir, {
+    path: dir,
+    keys
+  })
+  t.equals(typeof db.jitdb, 'object')
+  db.onDrain(() => {
+    db.query(
+      toCallback((err1, msgs) => {
+        t.error(err1, 'no err')
+        t.equal(msgs.length, 100)
+        t.end()
+      })
+    )
+  })
+})
+
+// FIXME:
+test.skip('migrated db stays up-to-date as the old log is updated', (t) => {
+  db.onDrain(() => {
+    db.query(
+      toCallback((err1, msgs) => {
+        t.error(err1, 'no err')
+        t.equal(msgs.length, 100)
+
+        const sbot = SecretStack({appKey: caps.shs})
+          .use(require('ssb-db'))
+          .call(null, {keys, path: dir})
+        sbot.publish({ type: 'post', text: 'Extra post' }, (err2, posted) => {
+          t.error(err2, 'no err')
+          t.equals(posted.value.content.type, 'post')
+
+          db.onDrain(() => {
+            db.query(
+              toCallback((err3, msgs2) => {
+                t.error(err3, 'no err')
+                t.equal(msgs2.length, 101)
+                t.end()
+              })
+            )
+          })
+        })
+      })
+    )
+  })
+})

--- a/test/migration.js
+++ b/test/migration.js
@@ -7,6 +7,8 @@ const SecretStack = require('secret-stack')
 const caps = require('ssb-caps')
 const generateFixture = require('ssb-fixtures')
 const fs = require('fs')
+const pull = require('pull-stream')
+const fromEvent = require('pull-stream-util/from-event')
 const { toCallback } = require('../operators')
 
 const dir = '/tmp/ssb-db2-migration'
@@ -14,11 +16,13 @@ const dir = '/tmp/ssb-db2-migration'
 rimraf.sync(dir)
 mkdirp.sync(dir)
 
+const TOTAL = 10
+
 test('generate fixture with flumelog-offset', (t) => {
   generateFixture({
     outputDir: dir,
     seed: 'migration',
-    messages: 2,
+    messages: TOTAL,
     authors: 5,
     slim: true,
   }).then(() => {
@@ -37,21 +41,43 @@ test('migration moves msgs from old log to new log', (t) => {
     .use(require('../migration'))
     .call(null, { keys, path: dir })
 
-  // FIXME: replace setTimeout with migration progress events
-  setTimeout(() => {
-    t.true(fs.existsSync(path.join(dir, 'db2', 'log.bipf')), 'migration done')
-    sbot.db.onDrain(() => {
-      sbot.db.query(
-        toCallback((err1, msgs) => {
-          t.error(err1, 'no err')
-          t.equal(msgs.length, 2)
-          sbot.close(() => {
-            t.end()
-          })
-        })
-      )
+  let progressEventsReceived = false
+  pull(
+    fromEvent('ssb:db2:migration:progress', sbot),
+    pull.take(TOTAL),
+    pull.collect((err, nums) => {
+      t.error(err)
+      t.equals(nums.length, TOTAL, `${TOTAL} progress events emitted`)
+      t.equals(nums[0], 0, 'first progress event is zero')
+      t.true(nums[0] < nums[1], 'monotonically increasing')
+      t.true(nums[1] < nums[2], 'monotonically increasing')
+      t.equals(nums[TOTAL - 1], 1, 'last progress event is one')
+      progressEventsReceived = true
     })
-  }, 1000)
+  )
+
+  pull(
+    fromEvent('ssb:db2:migration:progress', sbot),
+    pull.filter((x) => x === 1),
+    pull.take(1),
+    // FIXME: why do we still need a setTimeout?
+    pull.asyncMap((x, cb) => setTimeout(cb, 500)),
+    pull.drain(() => {
+      t.true(fs.existsSync(path.join(dir, 'db2', 'log.bipf')), 'migration done')
+      sbot.db.onDrain(() => {
+        sbot.db.query(
+          toCallback((err1, msgs) => {
+            t.error(err1, 'no err')
+            t.equal(msgs.length, TOTAL)
+            t.true(progressEventsReceived, 'progress events received')
+            sbot.close(() => {
+              t.end()
+            })
+          })
+        )
+      })
+    })
+  )
 })
 
 test('migration keeps new log synced with old log being updated', (t) => {
@@ -62,34 +88,50 @@ test('migration keeps new log synced with old log being updated', (t) => {
     .use(require('../migration'))
     .call(null, { keys, path: dir })
 
-  // FIXME: replace setTimeout with migration progress events
-  setTimeout(() => {
-    t.true(fs.existsSync(path.join(dir, 'db2', 'log.bipf')), 'migration done')
-    sbot.db.onDrain(() => {
-      sbot.db.query(
-        toCallback((err1, msgs) => {
-          t.error(err1, '1st query suceeded')
-          t.equal(msgs.length, 2, '2 msgs')
+  pull(
+    fromEvent('ssb:db2:migration:progress', sbot),
+    pull.filter((x) => x === 1),
+    pull.take(1),
+    // FIXME: why do we still need a setTimeout?
+    pull.asyncMap((x, cb) => setTimeout(cb, 500)),
+    pull.drain(() => {
+      t.true(fs.existsSync(path.join(dir, 'db2', 'log.bipf')), 'migration done')
+      sbot.db.onDrain(() => {
+        sbot.db.query(
+          toCallback((err1, msgs) => {
+            t.error(err1, '1st query suceeded')
+            t.equal(msgs.length, TOTAL, `${TOTAL} msgs`)
 
-          sbot.publish({ type: 'post', text: 'Extra post' }, (err2, posted) => {
-            t.error(err2, 'publish suceeded')
-            t.equals(posted.value.content.type, 'post', 'msg posted')
-
-            // FIXME: replace setTimeout with migration progress events
-            setTimeout(() => {
-              sbot.db.query(
-                toCallback((err3, msgs2) => {
-                  t.error(err3, '2nd query suceeded')
-                  t.equal(msgs2.length, 3, '3 msgs')
-                  sbot.close(() => {
-                    t.end()
+            // This should run after the sbot.publish completes
+            pull(
+              fromEvent('ssb:db2:migration:progress', sbot),
+              pull.filter((x) => x === 1),
+              pull.take(1),
+              // FIXME: why do we still need a setTimeout?
+              pull.asyncMap((x, cb) => setTimeout(cb, 500)),
+              pull.drain(() => {
+                sbot.db.query(
+                  toCallback((err3, msgs2) => {
+                    t.error(err3, '2nd query suceeded')
+                    t.equal(msgs2.length, TOTAL + 1, `${TOTAL + 1} msgs`)
+                    sbot.close(() => {
+                      t.end()
+                    })
                   })
-                })
-              )
-            }, 1000)
+                )
+              })
+            )
+
+            sbot.publish(
+              { type: 'post', text: 'Extra post' },
+              (err2, posted) => {
+                t.error(err2, 'publish suceeded')
+                t.equals(posted.value.content.type, 'post', 'msg posted')
+              }
+            )
           })
-        })
-      )
+        )
+      })
     })
-  }, 1000)
+  )
 })

--- a/test/operators.js
+++ b/test/operators.js
@@ -13,7 +13,7 @@ mkdirp.sync(dir)
 
 const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
-const db = DB.init(dir, {
+const db = DB.init({}, dir, {
   path: dir,
   keys,
 })

--- a/test/social-index.js
+++ b/test/social-index.js
@@ -15,7 +15,7 @@ mkdirp.sync(dir)
 
 const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
-const db = DB.init(dir, {
+const db = DB.init({}, dir, {
   path: dir,
   keys,
 })

--- a/test/validate.js
+++ b/test/validate.js
@@ -11,7 +11,7 @@ const dir = '/tmp/ssb-db2-validate'
 rimraf.sync(dir)
 mkdirp.sync(dir)
 
-const ssbDB = DB.init(dir, {
+const ssbDB = DB.init({}, dir, {
   path: dir,
   keys: ssbKeys.loadOrCreateSync(path.join(dir, 'secret')),
 })


### PR DESCRIPTION
- [x] Copy and adapt the script from jitdb ('copy-json-to-bipf-async')
- [x] Tests
- [x] Support `live: true`
- [x] Reuse the same async-flumelog instance instead of recreating it
- [x] If new log already exists with N msgs, skip N msgs scanned from old log
- [x] Progress indicator (percentual) events for migration
- [x] If old log does not exist, migration plugin does not crash
- [x] If old log still exists, refuse to allow db2.add and db2.publish
- [x] Update README
- [ ] API to nuke the old log
  - Protect ourselves against forking when maintaining new log alongside old log
  - "force only one source of truth"
  - consider deleting the old log, or replacing it with broken data

