### PR TITLE
refactor usage of debug()

### DIFF
--- a/indexes/base.js
+++ b/indexes/base.js
@@ -1,7 +1,6 @@
 const bipf = require('bipf')
 const pl = require('pull-level')
 const pull = require('pull-stream')
-const debug = require('debug')("base-index")
 const Plugin = require('./plugin')
 
 // 3 indexes:
@@ -52,7 +51,7 @@ module.exports = function (log, dir, feedId) {
 
       batchJsonKey.push({ type: 'put', key: [author, sequence],
                           value: data.seq })
-      
+
       var latestSequence = 0
       if (authorLatest[author])
         latestSequence = authorLatest[author].sequence
@@ -76,7 +75,7 @@ module.exports = function (log, dir, feedId) {
     })
   }
 
-  let { level, seq } = Plugin(log, dir, "base", 1, debug,
+  let { level, seq } = Plugin(log, dir, "base", 1,
                               handleData, writeData, beforeIndexUpdate)
 
   function getAllLatest(cb) {
@@ -95,7 +94,7 @@ module.exports = function (log, dir, feedId) {
       })
     )
   }
-  
+
   function levelKeyToMessage(key, cb) {
     level.get(key, (err, seq) => {
       if (err) return cb(err)
@@ -106,7 +105,7 @@ module.exports = function (log, dir, feedId) {
         })
     })
   }
-  
+
   var self = {
     seq,
     remove: level.clear,

--- a/indexes/social.js
+++ b/indexes/social.js
@@ -3,7 +3,6 @@ const sort = require('ssb-sort')
 const push = require('push-stream')
 const pl = require('pull-level')
 const pull = require('pull-stream')
-const debug = require('debug')("social-index")
 const Plugin = require('./plugin')
 const {query, fromDB, and, offsets} = require('../operators')
 
@@ -104,7 +103,7 @@ module.exports = function (log, jitdb, dir, feedId) {
   }
 
   const name = "social"
-  let { level, seq } = Plugin(log, dir, name, 1, debug, handleData, writeData)
+  let { level, seq } = Plugin(log, dir, name, 1, handleData, writeData)
 
   return {
     seq,


### PR DESCRIPTION
First I noticed that we could use `debug` with namespaces such as `"ssb:db2:stuff"`, which is standard practice in [debug](https://www.npmjs.com/package/debug), allowing us to filter them in runtime like this: `DEBUG=ssb:* node myapp.js` or `DEBUG=ssb:db2:* node myappjs`.

Then, I refactored a bit so that we can get rid of one argument out of the 8 (many!) arguments to `Plugin()`.