### PR TITLE
refactor: move lines around, use const/let

### DIFF
--- a/compat/ebt.js
+++ b/compat/ebt.js
@@ -5,8 +5,8 @@ exports.init = function (sbot, config) {
     sbot.db.getAllLatest((err, last) => {
       if (err) return cb(err)
 
-      var clock = {}
-      for (var k in last) {
+      const clock = {}
+      for (const k in last) {
         clock[k] = last[k].sequence
       }
 

--- a/compat/history-stream.js
+++ b/compat/history-stream.js
@@ -41,7 +41,7 @@ exports.init = function (sbot, config) {
     }
 
     function formatMsg(msg) {
-      let fixedMsg = originalData(msg)
+      const fixedMsg = originalData(msg)
       if (!keys && values)
         return fixedMsg.value
       else if (keys && !values)

--- a/indexes/partial.js
+++ b/indexes/partial.js
@@ -14,9 +14,9 @@ module.exports = function (dir) {
   const path = require('path')
 
   const queue = require('../waiting-queue')()
-  var state = {}
+  let state = {}
 
-  var f = AtomicFile(path.join(dir, 'db2', 'indexes', 'partial.json'))
+  const f = AtomicFile(path.join(dir, 'db2', 'indexes', 'partial.json'))
 
   f.get((err, data) => {
     if (data)
@@ -31,7 +31,8 @@ module.exports = function (dir) {
       if (err) console.error("error saving partial", err)
     })
   }
-  var saveState = debounce(atomicSave, 1000, { leading: true })
+
+  const saveState = debounce(atomicSave, 1000, { leading: true })
 
   function save(cb) {
     saveState()

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -5,9 +5,6 @@ const Debug = require('debug')
 
 module.exports = function (log, dir, name, version,
                            handleData, writeData, beforeIndexUpdate) {
-  var seq = Obv()
-  seq.set(-1)
-
   const indexesPath = path.join(dir, 'db2', 'indexes', name)
   const debug = Debug('ssb:db2:' + name)
 
@@ -16,12 +13,13 @@ module.exports = function (log, dir, name, version,
     mkdirp.sync(indexesPath)
   }
 
-  var level = Level(indexesPath)
+  const level = Level(indexesPath)
   const META = '\x00'
-
   const chunkSize = 512
-  var isLive = false
-  var processed = 0
+  let isLive = false
+  let processed = 0
+  const seq = Obv()
+  seq.set(-1)
 
   function updateIndexes() {
     const start = Date.now()

--- a/indexes/social.js
+++ b/indexes/social.js
@@ -24,7 +24,7 @@ module.exports = function (log, jitdb, dir, feedId) {
   const bVote = Buffer.from('vote')
   const bLink = Buffer.from('link')
 
-  var batch = []
+  let batch = []
 
   function writeData(cb) {
     level.batch(batch, { keyEncoding: 'json' }, cb)
@@ -32,7 +32,7 @@ module.exports = function (log, jitdb, dir, feedId) {
   }
 
   function handleData(data, processed) {
-    var p = 0 // note you pass in p!
+    let p = 0 // note you pass in p!
     p = bipf.seekKey(data.value, p, bKey)
     const shortKey = bipf.decode(data.value, p).slice(1, 10)
 
@@ -40,9 +40,9 @@ module.exports = function (log, jitdb, dir, feedId) {
     p = bipf.seekKey(data.value, p, bValue)
     if (~p) {
       // content
-      var pContent = bipf.seekKey(data.value, p, bContent)
+      const pContent = bipf.seekKey(data.value, p, bContent)
       if (~pContent) {
-        var pRoot = bipf.seekKey(data.value, pContent, bRoot)
+        const pRoot = bipf.seekKey(data.value, pContent, bRoot)
         if (~pRoot) {
           const root = bipf.decode(data.value, pRoot)
           if (root) {
@@ -51,7 +51,7 @@ module.exports = function (log, jitdb, dir, feedId) {
           }
         }
 
-        var pMentions = bipf.seekKey(data.value, pContent, bMentions)
+        const pMentions = bipf.seekKey(data.value, pContent, bMentions)
         if (~pMentions) {
           const mentionsData = bipf.decode(data.value, pMentions)
           if (Array.isArray(mentionsData)) {
@@ -66,12 +66,12 @@ module.exports = function (log, jitdb, dir, feedId) {
           }
         }
 
-        var pType = bipf.seekKey(data.value, pContent, bType)
+        const pType = bipf.seekKey(data.value, pContent, bType)
         if (~pType) {
           if (bipf.compareString(data.value, pType, bVote) === 0) {
-            var pVote = bipf.seekKey(data.value, pContent, bVote)
+            const pVote = bipf.seekKey(data.value, pContent, bVote)
             if (~pVote) {
-              var pLink = bipf.seekKey(data.value, pVote, bLink)
+              const pLink = bipf.seekKey(data.value, pVote, bLink)
               if (~pLink) {
                 const link = bipf.decode(data.value, pLink)
                 batch.push({ type: 'put', key: ['v', link, shortKey],
@@ -103,7 +103,7 @@ module.exports = function (log, jitdb, dir, feedId) {
   }
 
   const name = "social"
-  let { level, seq } = Plugin(log, dir, name, 1, handleData, writeData)
+  const { level, seq } = Plugin(log, dir, name, 1, handleData, writeData)
 
   return {
     seq,

--- a/log.js
+++ b/log.js
@@ -1,22 +1,22 @@
-var OffsetLog = require('async-flumelog')
-var bipf = require('bipf')
-var path = require('path')
+const OffsetLog = require('async-flumelog')
+const bipf = require('bipf')
+const path = require('path')
 
 module.exports = function (dir, config) {
   config = config || {}
 
-  var log = OffsetLog(
+  const log = OffsetLog(
     path.join(dir, 'db2', 'log.bipf'),
     { blockSize:1024*64 }
   )
 
   log.add = function (id, msg, cb) {
-    var data = {
+    const data = {
       key: id,
       value: msg,
       timestamp: Date.now()
     }
-    var b = Buffer.alloc(bipf.encodingLength(data))
+    const b = Buffer.alloc(bipf.encodingLength(data))
     bipf.encode(data, b, 0)
     log.append(b, function (err) {
       if (err) cb(err)

--- a/msg-utils.js
+++ b/msg-utils.js
@@ -1,18 +1,14 @@
-function isString (s) {
-  return typeof s === 'string'
-}
-
 exports.originalValue = function(value) {
-  var copy = {}
+  const copy = {}
 
-  for (let key in value) {
+  for (const key in value) {
     if (key !== 'meta' && key !== 'cyphertext' && key !== 'private' && key !== 'unbox') {
       copy[key] = value[key]
     }
   }
 
   if (value.meta && value.meta.original) {
-    for (let key in value.meta.original) {
+    for (const key in value.meta.original) {
       copy[key] = value.meta.original[key]
     }
   }

--- a/seekers.js
+++ b/seekers.js
@@ -1,4 +1,4 @@
-const bipf = require('bipf')
+const {seekKey} = require('bipf')
 
 const bValue = Buffer.from('value')
 const bAuthor = Buffer.from('author')
@@ -11,45 +11,45 @@ const bChannel = Buffer.from('channel')
 
 module.exports = {
   seekAuthor: function(buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, bValue)
+    let p = 0 // note you pass in p!
+    p = seekKey(buffer, p, bValue)
     if (!~p) return
-    return bipf.seekKey(buffer, p, bAuthor)
+    return seekKey(buffer, p, bAuthor)
   },
 
   seekType: function(buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, bValue)
+    let p = 0 // note you pass in p!
+    p = seekKey(buffer, p, bValue)
     if (!~p) return
-    p = bipf.seekKey(buffer, p, bContent)
+    p = seekKey(buffer, p, bContent)
     if (!~p) return
-    return bipf.seekKey(buffer, p, bType)
+    return seekKey(buffer, p, bType)
   },
 
   seekRoot: function(buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, bValue)
+    let p = 0 // note you pass in p!
+    p = seekKey(buffer, p, bValue)
     if (!~p) return
-    p = bipf.seekKey(buffer, p, bContent)
+    p = seekKey(buffer, p, bContent)
     if (!~p) return
-    return bipf.seekKey(buffer, p, bRoot)
+    return seekKey(buffer, p, bRoot)
   },
 
   seekPrivate: function(buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, bValue)
+    let p = 0 // note you pass in p!
+    p = seekKey(buffer, p, bValue)
     if (!~p) return
-    p = bipf.seekKey(buffer, p, bMeta)
+    p = seekKey(buffer, p, bMeta)
     if (!~p) return
-    return bipf.seekKey(buffer, p, bPrivate)
+    return seekKey(buffer, p, bPrivate)
   },
 
   seekChannel: function(buffer) {
-    var p = 0 // note you pass in p!
-    p = bipf.seekKey(buffer, p, bValue)
+    let p = 0 // note you pass in p!
+    p = seekKey(buffer, p, bValue)
     if (!~p) return
-    p = bipf.seekKey(buffer, p, bContent)
+    p = seekKey(buffer, p, bContent)
     if (!~p) return
-    return bipf.seekKey(buffer, p, bChannel)
+    return seekKey(buffer, p, bChannel)
   }
 }

--- a/test/base-index.js
+++ b/test/base-index.js
@@ -7,6 +7,7 @@ const ssbKeys = require('ssb-keys')
 const path = require('path')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
+const DB = require('../db')
 
 const dir = '/tmp/ssb-db2-base-index'
 
@@ -15,7 +16,6 @@ mkdirp.sync(dir)
 
 const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
-const DB = require('../db')
 const db = DB.init(dir, {
   path: dir,
   keys

--- a/test/operators.js
+++ b/test/operators.js
@@ -3,6 +3,7 @@ const ssbKeys = require('ssb-keys')
 const path = require('path')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
+const DB = require('../db')
 const {and, type, toCallback, author} = require('../operators')
 
 const dir = '/tmp/ssb-db2-operators'
@@ -12,7 +13,6 @@ mkdirp.sync(dir)
 
 const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
-const DB = require('../db')
 const db = DB.init(dir, {
   path: dir,
   keys

--- a/test/social-index.js
+++ b/test/social-index.js
@@ -3,6 +3,8 @@ const ssbKeys = require('ssb-keys')
 const path = require('path')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
+const DB = require('../db')
+const Social = require('../indexes/social')
 const {and, toCallback} = require('../operators')
 const {hasRoot, votesFor, mentions} = require('../operators/social')
 
@@ -13,13 +15,12 @@ mkdirp.sync(dir)
 
 const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
-const DB = require('../db')
 const db = DB.init(dir, {
   path: dir,
   keys
 })
 
-db.registerIndex(require('../indexes/social'))
+db.registerIndex(Social)
 
 test('getMessagesByMention', t => {
   const post = { type: 'post', text: 'Testing!' }

--- a/test/validate.js
+++ b/test/validate.js
@@ -3,14 +3,15 @@ const ssbKeys = require('ssb-keys')
 const path = require('path')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
+const validate = require('ssb-validate')
+const DB = require('../db')
 
 const dir = '/tmp/ssb-db2-validate'
 
 rimraf.sync(dir)
 mkdirp.sync(dir)
 
-const db = require('../db')
-const ssbDB = db.init(dir, {
+const ssbDB = DB.init(dir, {
   path: dir,
   keys: ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 })
@@ -42,9 +43,8 @@ test('Multiple', t => {
 })
 
 test('Raw feed with unused type + ooo', t => {
-  const validate = require('ssb-validate')
-  var state = validate.initial()
-  var keys = require('ssb-keys').generate()
+  let state = validate.initial()
+  const keys = ssbKeys.generate()
 
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test1' }, Date.now()) // ooo
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test2' }, Date.now()+1) // missing
@@ -79,9 +79,8 @@ test('Raw feed with unused type + ooo', t => {
 
 // we might get some messages from an earlier thread, and then get the latest 25 messages from the user
 test('Add with holes', t => {
-  const validate = require('ssb-validate')
-  var state = validate.initial()
-  var keys = require('ssb-keys').generate()
+  let state = validate.initial()
+  const keys = ssbKeys.generate()
 
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test1' }, Date.now()) // ooo
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test2' }, Date.now()+1) // missing
@@ -99,9 +98,8 @@ test('Add with holes', t => {
 })
 
 test('Add same message twice', t => {
-  const validate = require('ssb-validate')
-  var state = validate.initial()
-  var keys = require('ssb-keys').generate()
+  let state = validate.initial()
+  const keys = ssbKeys.generate()
 
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test1' }, Date.now())
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test2' }, Date.now()+1)
@@ -121,9 +119,8 @@ test('Add same message twice', t => {
 })
 
 test('Strict order basic case', t => {
-  const validate = require('ssb-validate')
-  var state = validate.initial()
-  var keys = require('ssb-keys').generate()
+  let state = validate.initial()
+  const keys = ssbKeys.generate()
 
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test1' }, Date.now())
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test2' }, Date.now()+1)
@@ -139,9 +136,8 @@ test('Strict order basic case', t => {
 })
 
 test('Strict order fail case', t => {
-  const validate = require('ssb-validate')
-  var state = validate.initial()
-  var keys = require('ssb-keys').generate()
+  let state = validate.initial()
+  const keys = ssbKeys.generate()
 
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test1' }, Date.now())
   state = validate.appendNew(state, null, keys, { type: 'post', text: 'test2' }, Date.now()+1)


### PR DESCRIPTION
These are simple refactors, mostly just for my sanity as I try to navigate the codebase, hope it's useful:

- `require`s always at the top, unless needed for browser differentiation
- `const` preferred if we know we won't re-assign the thing afterwards
- `let` preferred over `var` (var allows you to do the declaration twice, allowing some sneaky bugs pass through sometimes)
- variables used in scope declared at the top, inner functions declared below that (see `db.js` for an example)

This PR doesn't contain anything else interesting other than code shuffling.