### PR TITLE
Fix indexing performance by properly chunking writes

### DIFF
--- a/indexes/base.js
+++ b/indexes/base.js
@@ -78,7 +78,7 @@ module.exports = function (log, dir, feedId) {
       }
     }
 
-    if (batchBasic.length) return data.seq
+    if (batchBasic.length) return [batchBasic.length, data.seq]
     else return 0
   }
 

--- a/indexes/base.js
+++ b/indexes/base.js
@@ -78,7 +78,7 @@ module.exports = function (log, dir, feedId) {
       }
     }
 
-    if (batchBasic.length) return [batchBasic.length, data.seq]
+    if (batchBasic.length) return batchBasic.length
     else return 0
   }
 

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -48,10 +48,11 @@ module.exports = function (
     }
 
     function onData(data) {
-      unWrittenSeq = handleData(data, processed)
+      let r = handleData(data, processed)
+      unWrittenSeq = r[1]
       processed++
 
-      if (unWrittenSeq > chunkSize || isLive) {
+      if (r[0] > chunkSize || isLive) {
         writeBatch((err) => {
           if (err) throw err
           seq.set(data.seq)

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -48,11 +48,12 @@ module.exports = function (
     }
 
     function onData(data) {
-      let r = handleData(data, processed)
-      unWrittenSeq = r[1]
+      let unwritten = handleData(data, processed)
+      if (unwritten > 0)
+        unWrittenSeq = data.seq
       processed++
 
-      if (r[0] > chunkSize || isLive) {
+      if (unwritten > chunkSize || isLive) {
         writeBatch((err) => {
           if (err) throw err
           seq.set(data.seq)

--- a/indexes/social.js
+++ b/indexes/social.js
@@ -93,7 +93,7 @@ module.exports = function (log, jitdb, dir, feedId) {
       }
     }
 
-    if (batch.length) return data.seq
+    if (batch.length) return [batch.length, data.seq]
     else return 0
   }
 

--- a/indexes/social.js
+++ b/indexes/social.js
@@ -93,7 +93,7 @@ module.exports = function (log, jitdb, dir, feedId) {
       }
     }
 
-    if (batch.length) return [batch.length, data.seq]
+    if (batch.length) return batch.length
     else return 0
   }
 


### PR DESCRIPTION
This is rather embarrassing, I was fixing a bug related to unwrittenSeq a while ago and accidentily broke the chunkSize mechanism so it was more or less writing the whole time. With this commit indexing is 3x faster. 

I did discover some thing while tracking this down: chunksize 512 seems pretty good, I tried other values. Also the decode part is a large part of the indexing. The overhead of level is not so bad.