### PR TITLE
remove unused code in the indexes

### DIFF
--- a/db.js
+++ b/db.js
@@ -20,7 +20,7 @@ function getId(msg) {
 exports.init = function (sbot, dir, config) {
   const log = Log(dir, config)
   const jitdb = JITDb(log, path.join(dir, 'db2', 'indexes'))
-  const baseIndex = BaseIndex(log, dir, config.keys.public)
+  const baseIndex = BaseIndex(log, dir)
   const migrate = Migrate.init(sbot, config, log)
   //const contacts = fullIndex.contacts
   //const partial = Partial(dir)
@@ -264,7 +264,7 @@ exports.init = function (sbot, dir, config) {
   }
 
   function registerIndex(Index) {
-    const index = Index(log, jitdb, dir, config.keys.public)
+    const index = Index(log, dir)
 
     if (indexes[index.name]) throw 'Index already exists'
 

--- a/indexes/base.js
+++ b/indexes/base.js
@@ -8,7 +8,7 @@ const Plugin = require('./plugin')
 // - [author, sequence] => seq (EBT)
 // - author => latest { msg key, sequence timestamp } (validate state & EBT)
 
-module.exports = function (log, dir, feedId) {
+module.exports = function (log, dir) {
   const bValue = Buffer.from('value')
   const bKey = Buffer.from('key')
   const bAuthor = Buffer.from('author')

--- a/indexes/social.js
+++ b/indexes/social.js
@@ -1,17 +1,15 @@
 const bipf = require('bipf')
-const sort = require('ssb-sort')
-const push = require('push-stream')
 const pl = require('pull-level')
 const pull = require('pull-stream')
 const Plugin = require('./plugin')
-const { query, fromDB, and, offsets } = require('../operators')
+const { offsets } = require('../operators')
 
 // 3 indexes:
 // - root (msgId) => msg seqs
 // - mentions (msgId) => msg seqs
 // - votes (msgId) => msg seqs
 
-module.exports = function (log, jitdb, dir, feedId) {
+module.exports = function (log, dir) {
   const bKey = Buffer.from('key')
   const bValue = Buffer.from('value')
   const bContent = Buffer.from('content')
@@ -97,17 +95,8 @@ module.exports = function (log, jitdb, dir, feedId) {
     else return 0
   }
 
-  function getMessagesFromSeqs(seqs, cb) {
-    push(
-      push.values(seqs),
-      push.asyncMap(log.get),
-      push.collect((err, results) => {
-        const msgs = results.map((x) => bipf.decode(x, 0))
-        sort(msgs)
-        msgs.reverse()
-        cb(null, msgs)
-      })
-    )
+  function parseInt10(x) {
+    return parseInt(x, 10)
   }
 
   const name = 'social'
@@ -129,10 +118,7 @@ module.exports = function (log, jitdb, dir, feedId) {
         pull.collect((err, data) => {
           if (err) return cb(err)
 
-          cb(
-            null,
-            query(fromDB(jitdb), and(offsets(data.map((x) => parseInt(x)))))
-          )
+          cb(null, offsets(data.map(parseInt10)))
         })
       )
     },
@@ -147,10 +133,7 @@ module.exports = function (log, jitdb, dir, feedId) {
         pull.collect((err, data) => {
           if (err) return cb(err)
 
-          cb(
-            null,
-            query(fromDB(jitdb), and(offsets(data.map((x) => parseInt(x)))))
-          )
+          cb(null, offsets(data.map(parseInt10)))
         })
       )
     },
@@ -165,10 +148,7 @@ module.exports = function (log, jitdb, dir, feedId) {
         pull.collect((err, data) => {
           if (err) return cb(err)
 
-          cb(
-            null,
-            query(fromDB(jitdb), and(offsets(data.map((x) => parseInt(x)))))
-          )
+          cb(null, offsets(data.map(parseInt10)))
         })
       )
     },


### PR DESCRIPTION
I started by removing `query`, `fromDB`, `and` from the social index, and then realized there were other things not used. I'm pretty sure we are capable of bringing all these changes back, if in the future we realize we need them, but for now it seems better to not let dead code lying around possibly mistaken as important code.