### PR TITLE
Allow `migrate` to be included alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ const sbot = SecretStack({appKey: caps.shs})
 
 However, note that while the old log exists, it will be continously migrated to the new log, and ssb-db2 forbids you to use its database-writing APIs such as `add()`, `publish()`, `del()` and so forth, to prevent the two logs from diverging into inconsistent states. The old log will remain the source of truth and keep getting copied into the new log, until the old log file does not exist anymore.
 
+### Migrating without including ssb-db2
+
+Because ssb-db2 also begins indexing basic metadata once it's included as a plugin, this may cost more (precious) CPU time. **If you are not yet using db2 APIs** but would like to migrate the log anyway, in preparation for later activating db2, then you can include only the migration plugin, like this:
+
+```js
+const sbot = SecretStack({appKey: caps.shs})
+  .use(require('ssb-db2/migrate'))
+  .call(null, config)
+```
+
+Note that the `start` behavior is the same: you can either start it automatically using `config.db2.automigrate` or manually like this:
+
+```js
+sbot.db2migrate.start()
+```
+
 ## Methods
 
 FIXME: add documentation for these

--- a/db.js
+++ b/db.js
@@ -2,12 +2,12 @@ const push = require('push-stream')
 const hash = require('ssb-keys/util').hash
 const validate = require('ssb-validate')
 const keys = require('ssb-keys')
-const path = require('path')
 const Obv = require('obv')
 const promisify = require('promisify-4loc')
 const jitdbOperators = require('jitdb/operators')
 const JITDb = require('jitdb')
 
+const { indexesPath } = require('./defaults')
 const Log = require('./log')
 const BaseIndex = require('./indexes/base')
 const Migrate = require('./migrate')
@@ -19,7 +19,7 @@ function getId(msg) {
 
 exports.init = function (sbot, dir, config) {
   const log = Log(dir, config)
-  const jitdb = JITDb(log, path.join(dir, 'db2', 'indexes'))
+  const jitdb = JITDb(log, indexesPath(dir))
   const baseIndex = BaseIndex(log, dir)
   const migrate = Migrate.init(sbot, config, log)
   //const contacts = fullIndex.contacts

--- a/defaults.js
+++ b/defaults.js
@@ -1,0 +1,6 @@
+const path = require('path')
+
+exports.BLOCK_SIZE = 64 * 1024
+exports.oldLogPath = (dir) => path.join(dir, 'flume', 'log.offset')
+exports.newLogPath = (dir) => path.join(dir, 'db2', 'log.bipf')
+exports.indexesPath = (dir) => path.join(dir, 'db2', 'indexes')

--- a/indexes/partial.js
+++ b/indexes/partial.js
@@ -12,11 +12,12 @@ module.exports = function (dir) {
   const AtomicFile = require('atomic-file')
   const debounce = require('lodash.debounce')
   const path = require('path')
+  const { indexesPath } = require('../defaults')
 
   const queue = require('../waiting-queue')()
   let state = {}
 
-  const f = AtomicFile(path.join(dir, 'db2', 'indexes', 'partial.json'))
+  const f = AtomicFile(path.join(indexesPath(dir), 'partial.json'))
 
   f.get((err, data) => {
     if (data) state = data.state

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -2,6 +2,7 @@ const Obv = require('obv')
 const Level = require('level')
 const path = require('path')
 const Debug = require('debug')
+const { indexesPath } = require('../defaults')
 
 module.exports = function (
   log,
@@ -12,16 +13,16 @@ module.exports = function (
   writeData,
   beforeIndexUpdate
 ) {
-  const indexesPath = path.join(dir, 'db2', 'indexes', name)
+  const indexPath = path.join(indexesPath(dir), name)
   const debug = Debug('ssb:db2:' + name)
 
   if (typeof window === 'undefined') {
     // outside browser
     const mkdirp = require('mkdirp')
-    mkdirp.sync(indexesPath)
+    mkdirp.sync(indexPath)
   }
 
-  const level = Level(indexesPath)
+  const level = Level(indexPath)
   const META = '\x00'
   const chunkSize = 512
   let isLive = false
@@ -49,8 +50,7 @@ module.exports = function (
 
     function onData(data) {
       let unwritten = handleData(data, processed)
-      if (unwritten > 0)
-        unWrittenSeq = data.seq
+      if (unwritten > 0) unWrittenSeq = data.seq
       processed++
 
       if (unwritten > chunkSize || isLive) {

--- a/log.js
+++ b/log.js
@@ -1,12 +1,12 @@
 const OffsetLog = require('async-flumelog')
 const bipf = require('bipf')
-const path = require('path')
+const { BLOCK_SIZE, newLogPath } = require('./defaults')
 
 module.exports = function (dir, config) {
   config = config || {}
 
-  const log = OffsetLog(path.join(dir, 'db2', 'log.bipf'), {
-    blockSize: 1024 * 64,
+  const log = OffsetLog(newLogPath(dir), {
+    blockSize: BLOCK_SIZE,
   })
 
   log.add = function (id, msg, cb) {

--- a/test/migration-alone.js
+++ b/test/migration-alone.js
@@ -1,0 +1,65 @@
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+const generateFixture = require('ssb-fixtures')
+const fs = require('fs')
+const pull = require('pull-stream')
+const fromEvent = require('pull-stream-util/from-event')
+
+const dir = '/tmp/ssb-db2-migrate-alone'
+
+rimraf.sync(dir)
+mkdirp.sync(dir)
+
+const TOTAL = 10
+
+test('generate fixture with flumelog-offset', (t) => {
+  generateFixture({
+    outputDir: dir,
+    seed: 'migrate',
+    messages: TOTAL,
+    authors: 5,
+    slim: true,
+  }).then(() => {
+    t.true(
+      fs.existsSync(path.join(dir, 'flume', 'log.offset')),
+      'log.offset was created'
+    )
+    t.end()
+  })
+})
+
+test('migrate (alone) moves msgs from old log to new log', (t) => {
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../migrate'))
+    .call(null, { keys, path: dir })
+
+  sbot.db2migrate.start()
+
+  pull(
+    fromEvent('ssb:db2:migrate:progress', sbot),
+    pull.take(TOTAL),
+    pull.collect((err, nums) => {
+      t.error(err)
+      t.equals(nums.length, TOTAL, `${TOTAL} progress events emitted`)
+      t.equals(nums[0], 0, 'first progress event is zero')
+      t.true(nums[0] < nums[1], 'monotonically increasing')
+      t.true(nums[1] < nums[2], 'monotonically increasing')
+      t.equals(nums[TOTAL - 1], 1, 'last progress event is one')
+      setTimeout(() => {
+        t.true(
+          fs.existsSync(path.join(dir, 'db2', 'log.bipf')),
+          'migration done'
+        )
+        sbot.close(() => {
+          t.end()
+        })
+      }, 1000)
+    })
+  )
+})


### PR DESCRIPTION
For issue #32 