### PR TITLE
Support live queries in social index

### DIFF
--- a/operators/social.js
+++ b/operators/social.js
@@ -2,19 +2,19 @@ const { deferred } = require('jitdb/operators')
 
 function hasRoot(msgKey) {
   return deferred((meta, cb) => {
-    meta.db2.indexes.social.getMessagesByRoot(msgKey, cb)
+    meta.db2.indexes.social.getMessagesByRoot(msgKey, meta.live, cb)
   })
 }
 
 function votesFor(msgKey) {
   return deferred((meta, cb) => {
-    meta.db2.indexes.social.getMessagesByVoteLink(msgKey, cb)
+    meta.db2.indexes.social.getMessagesByVoteLink(msgKey, meta.live, cb)
   })
 }
 
 function mentions(key) {
   return deferred((meta, cb) => {
-    meta.db2.indexes.social.getMessagesByMention(key, cb)
+    meta.db2.indexes.social.getMessagesByMention(key, meta.live, cb)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "husky": "^4.3.0",
-    "jitdb": "~0.17.0",
+    "jitdb": "^0.19.0",
     "level": "^6.0.1",
     "lodash.debounce": "^4.0.8",
     "mkdirp": "^1.0.4",

--- a/test/social-index.js
+++ b/test/social-index.js
@@ -3,9 +3,10 @@ const ssbKeys = require('ssb-keys')
 const path = require('path')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
+const pull = require('pull-stream')
 const DB = require('../db')
 const Social = require('../indexes/social')
-const { and, toCallback } = require('../operators')
+const { and, toCallback, live, toPullStream } = require('../operators')
 const { hasRoot, votesFor, mentions } = require('../operators/social')
 
 const dir = '/tmp/ssb-db2-social-index'
@@ -147,6 +148,59 @@ test('getMessagesByVoteLink', (t) => {
             })
           )
         })
+      })
+    })
+  })
+})
+
+test('liveMessagesByVoteLink', (t) => {
+  const post = { type: 'post', text: 'Testing!' }
+
+  db.publish(post, (err, postMsg) => {
+    t.error(err, 'no err')
+
+    const voteMsg1 = {
+      type: 'vote',
+      vote: {
+        link: postMsg.key,
+        value: 1,
+        expression: '❤',
+      },
+    }
+
+    const voteMsg2 = {
+      type: 'vote',
+      vote: {
+        link: postMsg.key,
+        value: -1,
+        expression: '❤',
+      },
+    }
+
+    db.publish(voteMsg1, (err, v1) => {
+      t.error(err, 'no err')
+
+      db.onDrain('social', () => {
+        let i = 0
+        pull(
+          db.query(
+            and(votesFor(postMsg.key)),
+            live(),
+            toPullStream(),
+            pull.drain((result) => {
+              if (i++ == 0) {
+                t.equal(result.key, v1.key)
+
+                db.publish(voteMsg2, (err, v2) => {
+                  t.error(err, 'no err')
+                })
+              } else {
+                t.equal(result.value.content.vote.value, -1)
+                t.end()
+              }
+            })
+          )
+        )
       })
     })
   })


### PR DESCRIPTION
This depends on the [jitdb PR](https://github.com/ssb-ngi-pointer/jitdb/pull/38).

Allows the following kind of queries for all votes for a specific msg and all live updates:

```
db.query(
  and(votesFor(postMsg.key)),
  live(),
  toPullStream(),
  pull.drain((result) => {
 })
)
```