### PR TITLE
Don't run live stream until after we finish write the seq

### DIFF
--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -61,8 +61,7 @@ module.exports = function (
       }
     }
 
-    function liveStream()
-    {
+    function liveStream() {
       isLive = true
       log.stream({ gt: seq.value, live: true }).pipe({
         paused: false,
@@ -80,11 +79,10 @@ module.exports = function (
             seq.set(unWrittenSeq)
             liveStream()
           })
-        } else
-          liveStream()
+        } else liveStream()
 
         debug(`index scan time: ${Date.now() - start}ms, items: ${processed}`)
-      }
+      },
     })
   }
 

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -61,6 +61,15 @@ module.exports = function (
       }
     }
 
+    function liveStream()
+    {
+      isLive = true
+      log.stream({ gt: seq.value, live: true }).pipe({
+        paused: false,
+        write: onData,
+      })
+    }
+
     log.stream({ gt: seq.value }).pipe({
       paused: false,
       write: onData,
@@ -69,17 +78,13 @@ module.exports = function (
           writeBatch((err) => {
             if (err) throw err
             seq.set(unWrittenSeq)
+            liveStream()
           })
-        }
+        } else
+          liveStream()
 
         debug(`index scan time: ${Date.now() - start}ms, items: ${processed}`)
-
-        isLive = true
-        log.stream({ gt: seq.value, live: true }).pipe({
-          paused: false,
-          write: onData,
-        })
-      },
+      }
     })
   }
 

--- a/indexes/social.js
+++ b/indexes/social.js
@@ -37,7 +37,6 @@ module.exports = function (log, dir) {
     p = 0
     p = bipf.seekKey(data.value, p, bValue)
     if (~p) {
-      // content
       const pContent = bipf.seekKey(data.value, p, bContent)
       if (~pContent) {
         const pRoot = bipf.seekKey(data.value, pContent, bRoot)
@@ -46,7 +45,7 @@ module.exports = function (log, dir) {
           if (root) {
             batch.push({
               type: 'put',
-              key: [root, 'r',  shortKey],
+              key: [root, 'r', shortKey],
               value: processed,
             })
           }


### PR DESCRIPTION
One more of these *facepalm* bugs. With this, the index time of private (that I'm working on) goes down from 10 seconds to 2 seconds :-) And social from 12 to 7.