### PR TITLE
fix migrate plugin handling of old log existence

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -99,7 +99,7 @@ exports.init = function init(sbot, config, newLogMaybe) {
   let retryPeriod = 250
   let timer
 
-  function oldLogMissingRetry(fn) {
+  function oldLogMissingThenRetry(fn) {
     if (!hasCloseHook) {
       sbot.close.hook(function (fn, args) {
         clearTimeout(timer)
@@ -122,7 +122,7 @@ exports.init = function init(sbot, config, newLogMaybe) {
 
   function start() {
     if (started) return
-    if (oldLogMissingRetry(start)) return
+    if (oldLogMissingThenRetry(start)) return
     started = true
     debug('started')
 


### PR DESCRIPTION
This was necessary to solve some race conditions I got when putting this plugin inside Manyverse.

Specifically, the flumelog-offset existed (as a file) but was of empty size, and doing a `live` streaming on that caused a crash in flumelog-offset.

This PR does two things:

- `fileExists` checks both that it exists and size > 0
- some exponential backoff retries of the `migrate.start()` function, handling corner cases such as closing the sbot

Tested that it works in production in Manyverse