### PR TITLE
disable import of Partial

### DIFF
--- a/db.js
+++ b/db.js
@@ -11,7 +11,7 @@ const { indexesPath } = require('./defaults')
 const Log = require('./log')
 const BaseIndex = require('./indexes/base')
 const Migrate = require('./migrate')
-const Partial = require('./indexes/partial')
+// const Partial = require('./indexes/partial')
 
 function getId(msg) {
   return '%' + hash(JSON.stringify(msg, null, 2))


### PR DESCRIPTION
`./indexes/partial` imports `../waiting-queue` which doesn't exist, and this causes `noderify` to crash when building the backend in Manyverse.

I'd need this merged and released soon, if you can, @arj03 