### PR TITLE
Remove pull-drain-gently

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,6 @@ Note that the `start` behavior is the same: you can either start it automaticall
 sbot.db2migrate.start()
 ```
 
-### Migrating gently
-
-If migrating to the new log is not a priority over other computations and UI responses, you can choose to do the migration tasks gently, respecting current CPU usage. To enable this mode, set `config.db2.migrateMaxCpu` to a number between 1 and 100 representing the maximum CPU load allowed for this task. Underneath, it will use [`pull-drain-gently`](https://gitlab.com/staltz/pull-drain-gently/). You can also set `config.db2.migrateMaxPause`, which is a parameter handed down to `pull-drain-gently`, [read more about it here](https://gitlab.com/staltz/pull-drain-gently/#tweaking-the-parameters).
-
 ## Methods
 
 FIXME: add documentation for these

--- a/migrate.js
+++ b/migrate.js
@@ -196,13 +196,22 @@ exports.init = function init(sbot, config, newLogMaybe) {
             if (err) return console.error(err)
             debug('done migrating %s msgs from old log', msgCountOldLog)
 
+            let liveMsgCount = 0
+            if (debug.enabled) {
+              setInterval(() => {
+                if (liveMsgCount === 0) return
+                debug('%d msgs synced from old log to new log', liveMsgCount)
+                liveMsgCount = 0
+              }, 2000)
+            }
+
             pull(
               oldLogStreamLive,
               pull.map(updateMigratedSizeAndPluck),
               pull.map(toBIPF),
               pull.asyncMap(writeTo(newLog)),
               pull.drain(() => {
-                debug('1 new msg synced from old log to new log')
+                liveMsgCount++
               })
             )
           }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "pretty-quick": "^3.1.0",
     "promisify-4loc": "1.0.0",
     "pull-cont": "^0.1.1",
-    "pull-drain-gently": "^1.1.0",
     "pull-level": "^2.0.4",
     "pull-notify": "~0.1.1",
     "pull-stream": "^3.6.14",


### PR DESCRIPTION
Since `migrate` is I/O bound, not CPU bound, pull-drain-gently never gains us much, so I'd like to remove it to simplify the codebase. Should be easy to add back if we ever need it again. See also the other refactor commit contained here