### PR TITLE
Convert key index in base to an jitdb prefix index

### DIFF
--- a/db.js
+++ b/db.js
@@ -14,6 +14,8 @@ const Private = require('./indexes/private')
 const Migrate = require('./migrate')
 // const Partial = require('./indexes/partial')
 
+const { and, key, toCallback } = require('./operators')
+
 function getId(msg) {
   return '%' + hash(JSON.stringify(msg, null, 2))
 }
@@ -61,10 +63,14 @@ exports.init = function (sbot, dir, config) {
   }
 
   function get(id, cb) {
-    baseIndex.getMessageFromKey(id, (err, data) => {
-      if (data) cb(null, data.value)
-      else cb(err)
-    })
+    query(
+      and(key(id)),
+      toCallback((err, results) => {
+        if (err) return cb(err)
+        else if (results.length) return cb(null, results[0].value)
+        else return cb()
+      })
+    )
   }
 
   function add(msg, cb) {
@@ -82,8 +88,8 @@ exports.init = function (sbot, dir, config) {
       this problem.
     */
 
-    baseIndex.getMessageFromKey(id, (err, data) => {
-      if (data) cb(null, data.value)
+    get(id, (err, data) => {
+      if (data) cb(null, data)
       else log.add(id, msg, cb)
     })
   }

--- a/operators/index.js
+++ b/operators/index.js
@@ -5,6 +5,18 @@ function toBuffer(value) {
   return Buffer.isBuffer(value) ? value : Buffer.from(value)
 }
 
+function key(value) {
+  return {
+    type: 'EQUAL',
+    data: {
+      seek: seekers.seekKey,
+      value: Buffer.from(value),
+      indexType: 'key',
+      prefix: 32
+    },
+  }
+}
+
 function type(value) {
   return {
     type: 'EQUAL',
@@ -66,6 +78,7 @@ module.exports = Object.assign({}, jitdbOperators, {
   type,
   author,
   channel,
+  key,
   isRoot,
   isPrivate,
 })

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:arj03/ssb-db2.git"
   },
   "dependencies": {
-    "async-flumelog": "^1.0.9",
+    "async-flumelog": "^1.0.10",
     "atomically-universal": "^0.1.0",
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.3.0",
@@ -17,7 +17,7 @@
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "husky": "^4.3.0",
-    "jitdb": "^0.20.0",
+    "jitdb": "^0.23.0",
     "level": "^6.0.1",
     "lodash.debounce": "^4.0.8",
     "mkdirp": "^1.0.4",

--- a/seekers.js
+++ b/seekers.js
@@ -1,5 +1,6 @@
 const { seekKey } = require('bipf')
 
+const bKey = Buffer.from('key')
 const bValue = Buffer.from('value')
 const bAuthor = Buffer.from('author')
 const bContent = Buffer.from('content')
@@ -49,5 +50,10 @@ module.exports = {
     p = seekKey(buffer, p, bContent)
     if (!~p) return
     return seekKey(buffer, p, bChannel)
+  },
+
+  seekKey: function (buffer) {
+    var p = 0 // note you pass in p!
+    return seekKey(buffer, p, bKey)
   },
 }


### PR DESCRIPTION
This converts one of the level db indexes to a prefix index. I ran a test where I removed all indexes and lets it run followed by a query for a specific key. 

```
battery old: 53.2 s

arj@arj:~/dev/ssb-db2$ du --si ssb/db2/indexes/*
130M	ssb/db2/indexes/base
4,1k	ssb/db2/indexes/canDecrypt.index
529k	ssb/db2/indexes/encrypted.index
31M	ssb/db2/indexes/social

battery new: 51.7 s

arj@arj:~/dev/ssb-db2$ du --si ssb/db2/indexes/*
30M	ssb/db2/indexes/base
4,1k	ssb/db2/indexes/canDecrypt.index
529k	ssb/db2/indexes/encrypted.index
6,4M	ssb/db2/indexes/key.32prefix
6,4M	ssb/db2/indexes/offset.index
6,4M	ssb/db2/indexes/sequence.index
34M	ssb/db2/indexes/social
13M	ssb/db2/indexes/timestamp.index
```

While the speed up is not that big, one has to consider that the second had to create the jitdb indexes. The speedup will get bigger once we convert vote & root as well. But enough for today. 

The biggest difference is that this saves 94mb from the base index :)

Small note: running the same test on battery is around 32 seconds.
