### PR TITLE
refactor indexType names

### DIFF
--- a/operators/index.js
+++ b/operators/index.js
@@ -1,31 +1,38 @@
 const jitdbOperators = require('jitdb/operators')
-const seekers = require('../seekers')
+const {
+  seekKey,
+  seekType,
+  seekAuthor,
+  seekChannel,
+  seekRoot,
+  seekPrivate,
+} = require('../seekers')
 const { equal } = jitdbOperators
 
 function key(value) {
-  return equal(seekers.seekKey, value, { indexType: 'key', prefix: 32 })
+  return equal(seekKey, value, { indexType: 'key', prefix: 32 })
 }
 
 function type(value) {
-  return equal(seekers.seekType, value, { indexType: 'type' })
+  return equal(seekType, value, { indexType: 'value_content_type' })
 }
 
 function author(value) {
-  return equal(seekers.seekAuthor, value, { indexType: 'author' })
+  return equal(seekAuthor, value, { indexType: 'value_author' })
 }
 
 function channel(value) {
-  return equal(seekers.seekChannel, value, { indexType: 'channel' })
+  return equal(seekChannel, value, { indexType: 'value_content_channel' })
 }
 
 function isRoot() {
-  return equal(seekers.seekRoot, undefined, { indexType: 'root' })
+  return equal(seekRoot, undefined, { indexType: 'value_content_root' })
 }
 
 let bTrue = Buffer.alloc(1)
 bTrue[0] = 1
 function isPrivate() {
-  return equal(seekers.seekPrivate, bTrue, { indexType: 'private' })
+  return equal(seekPrivate, bTrue, { indexType: 'meta_private' })
 }
 
 module.exports = Object.assign({}, jitdbOperators, {


### PR DESCRIPTION
Just a refactor, not too important, and requires a reindex, but I figured that more descriptive/explicit is better for our future sanity and other developers, and this is not yet used in production, so now is the time to do this kind of refactor.

E.g. imagine if in the future we add another kind of of `private` e.g. `value.content.private`, then it makes it very clear what is what by making it explicit from day one.
