### PR TITLE
fix memory leak

### DIFF
--- a/indexes/private.js
+++ b/indexes/private.js
@@ -64,10 +64,16 @@ module.exports = function (dir, keys) {
 
   loadIndexes(() => {})
 
+  let savedTimer
   function saveIndexes(cb) {
-    save(encryptedFile, latestSeq, encrypted, () => {
-      save(canDecryptFile, latestSeq, canDecrypt, cb)
-    })
+    if (!savedTimer) {
+      savedTimer = setTimeout(() => {
+        savedTimer = null
+        save(encryptedFile, latestSeq, encrypted, () => {})
+        save(canDecryptFile, latestSeq, canDecrypt, () => {})
+      }, 1000)
+    }
+    cb()
   }
 
   const bKey = Buffer.from('key')


### PR DESCRIPTION
`atomically` behaves weirdly, and probably needs to be fixed:

Check https://github.com/fabiospampinato/atomically/blob/799d961964a27383f61a349af6d4a8e00c3b8395/src/utils/scheduler.ts#L48

If you call `write` many times synchronously (or "fast"), it just piles up a bunch of functions in this scheduler, and for some reason this logic only releases the queue of functions... when the queue is size 1. :sweat_smile: So it kept growing to thousands and thousands...

We should probably fix that, but a simple fix for now, which anyway made sense even if we didn't have a memleak, was to throttle the writes to the filesystem. These `saveIndexes` calls were super frequent, probably a bad idea:

```
/home/staltz/.ssb/db2/indexes/encrypted.index 	 12178 // size of atomically scheduler
saveIndexes at timestamp 1607350440744
/home/staltz/.ssb/db2/indexes/encrypted.index 	 12179
saveIndexes at timestamp 1607350440745
/home/staltz/.ssb/db2/indexes/encrypted.index 	 12180
saveIndexes at timestamp 1607350440745
/home/staltz/.ssb/db2/indexes/encrypted.index 	 12181
saveIndexes at timestamp 1607350440745
/home/staltz/.ssb/db2/indexes/encrypted.index 	 12182
```

Now they are much less frequent, and the scheduler gets emptied

```
saveIndexes at timestamp 1607350473379
/home/staltz/.ssb/db2/indexes/encrypted.index 	 1 // size of atomically scheduler
/home/staltz/.ssb/db2/indexes/encrypted.index 	 0
/home/staltz/.ssb/db2/indexes/canDecrypt.index 	 1
/home/staltz/.ssb/db2/indexes/canDecrypt.index 	 0
saveIndexes at timestamp 1607350474385
/home/staltz/.ssb/db2/indexes/encrypted.index 	 1
/home/staltz/.ssb/db2/indexes/encrypted.index 	 0
/home/staltz/.ssb/db2/indexes/canDecrypt.index 	 1
/home/staltz/.ssb/db2/indexes/canDecrypt.index 	 0
saveIndexes at timestamp 1607350475385
/home/staltz/.ssb/db2/indexes/encrypted.index 	 1
/home/staltz/.ssb/db2/indexes/encrypted.index 	 0
/home/staltz/.ssb/db2/indexes/canDecrypt.index 	 1
/home/staltz/.ssb/db2/indexes/canDecrypt.index 	 0
saveIndexes at timestamp 1607350476723
/home/staltz/.ssb/db2/indexes/encrypted.index 	 1
/home/staltz/.ssb/db2/indexes/encrypted.index 	 0
/home/staltz/.ssb/db2/indexes/canDecrypt.index 	 1
/home/staltz/.ssb/db2/indexes/canDecrypt.index 	 0
```
