### PR TITLE
Use one log stream for all indexes

### DIFF
--- a/db.js
+++ b/db.js
@@ -6,6 +6,7 @@ const Obv = require('obv')
 const promisify = require('promisify-4loc')
 const jitdbOperators = require('jitdb/operators')
 const JITDb = require('jitdb')
+const Debug = require('debug')
 
 const { indexesPath } = require('./defaults')
 const Log = require('./log')
@@ -28,6 +29,8 @@ exports.init = function (sbot, dir, config) {
   const migrate = Migrate.init(sbot, config, log)
   //const contacts = fullIndex.contacts
   //const partial = Partial(dir)
+
+  const debug = Debug('ssb:db2')
 
   const indexes = {
     base: baseIndex,
@@ -63,14 +66,16 @@ exports.init = function (sbot, dir, config) {
   }
 
   function get(id, cb) {
-    query(
-      and(key(id)),
-      toCallback((err, results) => {
-        if (err) return cb(err)
-        else if (results.length) return cb(null, results[0].value)
-        else return cb()
-      })
-    )
+    onIndexesReady(() => {
+      query(
+        and(key(id)),
+        toCallback((err, results) => {
+          if (err) return cb(err)
+          else if (results.length) return cb(null, results[0].value)
+          else return cb()
+        })
+      )
+    })
   }
 
   function add(msg, cb) {
@@ -110,6 +115,7 @@ exports.init = function (sbot, dir, config) {
     const guard = guardAgainstDuplicateLogs('del()')
     if (guard) return cb(guard)
 
+    // FIXME: this doesn't work anymore after changing base index
     baseIndex.keyToSeq(key, (err, seq) => {
       if (err) return cb(err)
       if (seq == null) return cb(new Error('seq is null!'))
@@ -256,6 +262,41 @@ exports.init = function (sbot, dir, config) {
     indexes[index.name] = index
   }
 
+  function updateIndexes() {
+    const start = Date.now()
+
+    const indexesRun = Object.values(indexes)
+    let isLive = false
+
+    function liveStream() {
+      debug('live streaming changes')
+      isLive = true
+      log.stream({ gt: indexes['base'].seq.value, live: true }).pipe({
+        paused: false,
+        write: (data) => indexesRun.forEach((x) => x.onData(data, isLive)),
+      })
+    }
+
+    const lowestSeq = Math.min(
+      ...Object.values(indexes).map((x) => x.seq.value)
+    )
+    debug(`lowest seq for all indexes ${lowestSeq}`)
+
+    log.stream({ gt: lowestSeq }).pipe({
+      paused: false,
+      write: (data) => indexesRun.forEach((x) => x.onData(data, isLive)),
+      end: () => {
+        const tasks = []
+        indexesRun.forEach((index) => {
+          tasks.push(promisify(index.writeBatch)())
+        })
+        Promise.all(tasks).then(liveStream)
+
+        debug(`index scan time: ${Date.now() - start}ms`)
+      },
+    })
+  }
+
   function onDrain(indexName, cb) {
     if (!cb) {
       // default
@@ -280,7 +321,31 @@ exports.init = function (sbot, dir, config) {
     })
   }
 
+  let indexesReady = Obv()
+  indexesReady.once(updateIndexes)
+  let closing = false
+
+  function checkIndexesReady() {
+    let allOk = private.latestSeq.value !== undefined
+    debug(`private seq: ${private.latestSeq.value}`)
+    for (var index in indexes) {
+      if (indexes[index].seq.value === undefined) allOk = false
+      debug(`${index} seq: ${indexes[index].seq.value}`)
+    }
+
+    if (allOk) indexesReady.set(true)
+    else if (!closing) setTimeout(checkIndexesReady, 250)
+  }
+
+  checkIndexesReady()
+
+  function onIndexesReady(cb) {
+    if (indexesReady.value === true) cb()
+    else indexesReady.once(cb)
+  }
+
   function close(cb) {
+    closing = true
     const tasks = []
     tasks.push(promisify(log.close)())
     for (const indexName in indexes) {

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -30,7 +30,7 @@ module.exports = function (
   let unWrittenSeq = -1
 
   function writeBatch(cb) {
-    if (unWrittenSeq > -1) {
+    if (unWrittenSeq > -1 && level._db.status !== 'closed') {
       level.put(
         META,
         { version, seq: unWrittenSeq, processed },

--- a/test/base-index.js
+++ b/test/base-index.js
@@ -7,7 +7,8 @@ const ssbKeys = require('ssb-keys')
 const path = require('path')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
-const DB = require('../db')
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
 
 const dir = '/tmp/ssb-db2-base-index'
 
@@ -16,10 +17,11 @@ mkdirp.sync(dir)
 
 const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
 
-const db = DB.init({}, dir, {
-  path: dir,
+const sbot = SecretStack({ appKey: caps.shs }).use(require('../')).call(null, {
   keys,
+  path: dir,
 })
+const db = sbot.db
 
 test('drain', (t) => {
   const post = { type: 'post', text: 'Testing!' }
@@ -166,7 +168,7 @@ test('db.close', (t) => {
 
     db.onDrain('base', () => {
       db.close(() => {
-        t.end()
+        sbot.close(t.end)
       })
     })
   })


### PR DESCRIPTION
The idea here is that instead of each plugin doing their own log stream we can have one stream driving them all. The improvement is substantial as was known from db1 and documented in #54. And the gain will only grow as new indexes are added. An added benefit is that with this we can merge #58 because in the case of a crash where base is then ahead of private, this will make sure that we continue from where private stopped. The overhead of calling the calls for indexes that are already up to date is minimal. Also because the indexes are pretty fast already, adding a new overhead will just give a 5 seconds delay before the normal indexes will start received new data.