### PR TITLE
dont use prefix for isRoot()

### DIFF
--- a/operators/index.js
+++ b/operators/index.js
@@ -51,7 +51,6 @@ function hasRoot(msgKey) {
 
 function isRoot() {
   return equal(seekRoot, null, {
-    prefix: 32,
     indexType: 'value_content_root',
   })
 }


### PR DESCRIPTION
I ran this example:

```js
 const results = await sbot.db.query(
    and(
      mentions('@QlCTpvY7p9ty2yOFrv1WU1AE88aoQc4Y7wYal7PFc+w=.ed25519'),
      isRoot(),
      channel('scuttlebutt')
    ),
    toPromise()
  )
```

and my computer crashed again, I think it has the same memory leak cause. But the news is that I also realized that it didn't complete the query within 40 seconds (database had a log.bipf but indexes folder was empty), but instead keep on running. I looked into the profiler and apparently `matchAgainstPrefix` was taking a long time (notice the right side of the picture):

![Screenshot from 2020-12-09 01-08-08](https://user-images.githubusercontent.com/90512/101552399-7afcfd80-39bb-11eb-8016-36848e601e9f.png)

This happens because there are lots and lots of false positives that `matchAgainstPrefix` has to go through, so I think we lose the benefit of prefix. Then, I removed the prefix (see the git diff), and the result looks like this (database had a log.bipf but indexes folder was empty):

![Screenshot from 2020-12-09 01-06-44](https://user-images.githubusercontent.com/90512/101552589-c3b4b680-39bb-11eb-871d-0ec4ec28a5fe.png)

It's also quite logical that it's probably better to have a boolean (bit) index for isRoot or not, and to be sure that there are no false positives involved. It also makes sense to keep the hasRoot prefix index, because there we want to pick values in `msg.value.content.root`.
