### PR TITLE
replace setTimeout in onIndexesStateLoaded with promises

### DIFF
--- a/indexes/base.js
+++ b/indexes/base.js
@@ -23,7 +23,7 @@ module.exports = function (log, dir, private) {
   let batchJson = []
   let authorLatest = {}
 
-  const { level, seq, onData, writeBatch } = Plugin(
+  const { level, seq, stateLoaded, onData, writeBatch } = Plugin(
     log,
     dir,
     'base',
@@ -123,6 +123,7 @@ module.exports = function (log, dir, private) {
 
   return {
     seq,
+    stateLoaded,
     onData,
     writeBatch,
 

--- a/indexes/mentions.js
+++ b/indexes/mentions.js
@@ -64,7 +64,7 @@ module.exports = function (log, dir) {
   }
 
   const name = 'mentions'
-  const { level, seq, onData, writeBatch } = Plugin(
+  const { level, seq, stateLoaded, onData, writeBatch } = Plugin(
     log,
     dir,
     name,
@@ -91,6 +91,7 @@ module.exports = function (log, dir) {
 
   return {
     seq,
+    stateLoaded,
     onData,
     writeBatch,
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lodash.debounce": "^4.0.8",
     "mkdirp": "^1.0.4",
     "obv": "0.0.1",
+    "p-defer": "^3.0.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
     "promisify-4loc": "1.0.0",
@@ -37,12 +38,12 @@
     "typedarray-to-buffer": "^4.0.0"
   },
   "devDependencies": {
-    "rimraf": "^3.0.2",
-    "ssb-fixtures": "2.2.0",
-    "ssb-db": "20.3.0",
-    "secret-stack": "6.3.1",
     "pull-stream-util": "0.1.2",
+    "rimraf": "^3.0.2",
+    "secret-stack": "6.3.1",
     "ssb-caps": "1.1.0",
+    "ssb-db": "20.3.0",
+    "ssb-fixtures": "2.2.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.1"
   },


### PR DESCRIPTION
`p-defer` is a ~6 LOC dependency. The approach here is to introduce a `stateLoaded` deferred promise (think: an Obv that can only be `set` once) instead of piggybacking on `seq`, and then collect all `stateLoaded` for all indexes using Promise.all