### PR TITLE
use official leveldb isClosed() API

### DIFF
--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -32,7 +32,7 @@ module.exports = function (
   let unWrittenSeq = -1
 
   function writeBatch(cb) {
-    if (unWrittenSeq > -1 && level._db.status !== 'closed') {
+    if (unWrittenSeq > -1 && !level.isClosed()) {
       level.put(
         META,
         { version, seq: unWrittenSeq, processed },


### PR DESCRIPTION
The official API for checking if level is closed is https://github.com/Level/level#dbisclosed

I ran the tests 100 times and couldn't bump into #35 anymore. Still not sure if this is a definitive solution though

```
for i in $(seq 100); do npm test; sleep 1; done
```