### PR TITLE
Implicit onDrain() when using db.query()

### DIFF
--- a/compat/history-stream.js
+++ b/compat/history-stream.js
@@ -50,17 +50,19 @@ exports.init = function (sbot, config) {
 
     return pull(
       pullCont(function (cb) {
-        if (!ref.isFeed(opts.id)) return cb(opts.id + ' is not a feed')
+        sbot.db.log.onDrain(() => {
+          if (!ref.isFeed(opts.id)) return cb(opts.id + ' is not a feed')
 
-        if (limit) {
-          sbot.db.jitdb.paginate(query, 0, limit, false, (err, answer) => {
-            cb(err, pull.values(answer.results.map(formatMsg)))
-          })
-        } else {
-          sbot.db.jitdb.all(query, 0, false, (err, results) => {
-            cb(err, pull.values(results.map(formatMsg)))
-          })
-        }
+          if (limit) {
+            sbot.db.jitdb.paginate(query, 0, limit, false, (err, answer) => {
+              cb(err, pull.values(answer.results.map(formatMsg)))
+            })
+          } else {
+            sbot.db.jitdb.all(query, 0, false, (err, results) => {
+              cb(err, pull.values(results.map(formatMsg)))
+            })
+          }
+        })
       })
     )
   }

--- a/db.js
+++ b/db.js
@@ -360,11 +360,6 @@ exports.init = function (sbot, dir, config) {
 
   return {
     get,
-    getSync: function (id, cb) {
-      onDrain('base', () => {
-        get(id, cb)
-      })
-    },
     add,
     publish,
     del,

--- a/operators/full-mentions.js
+++ b/operators/full-mentions.js
@@ -2,6 +2,10 @@ const { deferred } = require('jitdb/operators')
 
 module.exports = function mentions(key) {
   return deferred((meta, cb) => {
-    meta.db2.getIndexes().fullMentions.getMessagesByMention(key, meta.live, cb)
+    meta.db2.onDrain('fullMentions', () => {
+      meta.db2
+        .getIndexes()
+        .fullMentions.getMessagesByMention(key, meta.live, cb)
+    })
   })
 }

--- a/test/base-index.js
+++ b/test/base-index.js
@@ -57,25 +57,6 @@ test('get', (t) => {
   })
 })
 
-test('getsync', (t) => {
-  const post = { type: 'post', text: 'Testing!' }
-  const post2 = { type: 'post', text: 'Testing 2!' }
-
-  db.publish(post, (err, postMsg) => {
-    t.error(err, 'no err')
-
-    db.publish(post2, (err, postMsg2) => {
-      t.error(err, 'no err')
-
-      db.getSync(postMsg.key, (err, msg) => {
-        t.equal(msg.content.text, post.text, 'correct msg')
-
-        t.end()
-      })
-    })
-  })
-})
-
 test('get latest', (t) => {
   const post = { type: 'post', text: 'Testing!' }
 

--- a/test/base-index.js
+++ b/test/base-index.js
@@ -48,12 +48,10 @@ test('get', (t) => {
     db.publish(post2, (err, postMsg2) => {
       t.error(err, 'no err')
 
-      db.onDrain('base', () => {
-        db.get(postMsg.key, (err, msg) => {
-          t.equal(msg.content.text, post.text, 'correct msg')
+      db.get(postMsg.key, (err, msg) => {
+        t.equal(msg.content.text, post.text, 'correct msg')
 
-          t.end()
-        })
+        t.end()
       })
     })
   })
@@ -126,11 +124,9 @@ test('encrypted', (t) => {
   db.publish(content, (err, privateMsg) => {
     t.error(err, 'no err')
 
-    db.onDrain('base', () => {
-      db.get(privateMsg.key, (err, msg) => {
-        t.equal(msg.content.text, 'super secret')
-        t.end()
-      })
+    db.get(privateMsg.key, (err, msg) => {
+      t.equal(msg.content.text, 'super secret')
+      t.end()
     })
   })
 })
@@ -141,10 +137,8 @@ test('db.close', (t) => {
   db.publish(post, (err, postMsg) => {
     t.error(err, 'no err')
 
-    db.onDrain('base', () => {
-      db.close(() => {
-        sbot.close(t.end)
-      })
+    db.close(() => {
+      sbot.close(t.end)
     })
   })
 })

--- a/test/createHistoryStream.js
+++ b/test/createHistoryStream.js
@@ -34,17 +34,15 @@ test('Base', (t) => {
   state = validate.appendNew(state, null, otherKeys, otherMsg, Date.now())
   db.add(state.queue[0].value, (err) => {
     db.publish(post, (err, postMsg) => {
-      db.onDrain('base', () => {
-        pull(
-          sbot.createHistoryStream({ id: keys.id, keys: false }),
-          pull.collect((err, results) => {
-            t.equal(results.length, 1)
-            // values directly
-            t.equal(results[0].content.text, post.text)
-            t.end()
-          })
-        )
-      })
+      pull(
+        sbot.createHistoryStream({ id: keys.id, keys: false }),
+        pull.collect((err, results) => {
+          t.equal(results.length, 1)
+          // values directly
+          t.equal(results[0].content.text, post.text)
+          t.end()
+        })
+      )
     })
   })
 })
@@ -84,30 +82,28 @@ test('Seq', (t) => {
 
           const post = { type: 'post', text: 'Testing 2' }
           db.publish(post, (err, postMsg) => {
-            db.onDrain(() => {
-              pull(
-                sbot.createHistoryStream({ id: keys.id, keys: false, seq: 2 }),
-                pull.collect((err, results) => {
-                  t.equal(results.length, 1)
-                  t.equal(results[0].content.text, post.text)
+            pull(
+              sbot.createHistoryStream({ id: keys.id, keys: false, seq: 2 }),
+              pull.collect((err, results) => {
+                t.equal(results.length, 1)
+                t.equal(results[0].content.text, post.text)
 
-                  pull(
-                    sbot.createHistoryStream({
-                      id: keys.id,
-                      keys: false,
-                      seq: 1,
-                      limit: 1,
-                    }),
-                    pull.collect((err, results) => {
-                      t.equal(results.length, 1)
-                      t.equal(results[0].content.text, 'Testing!')
+                pull(
+                  sbot.createHistoryStream({
+                    id: keys.id,
+                    keys: false,
+                    seq: 1,
+                    limit: 1,
+                  }),
+                  pull.collect((err, results) => {
+                    t.equal(results.length, 1)
+                    t.equal(results[0].content.text, 'Testing!')
 
-                      t.end()
-                    })
-                  )
-                })
-              )
-            })
+                    t.end()
+                  })
+                )
+              })
+            )
           })
         })
       )
@@ -116,7 +112,7 @@ test('Seq', (t) => {
 })
 
 test('limit', (t) => {
-  db.publish({ type: 'post', text: 'Testing 2' }, (err, postMsg) => {
+  db.publish({ type: 'post', text: 'Testing 3' }, (err, postMsg) => {
     pull(
       sbot.createHistoryStream({ id: keys.id, limit: 1 }),
       pull.collect((err, results) => {
@@ -126,7 +122,7 @@ test('limit', (t) => {
         pull(
           sbot.createHistoryStream({ id: keys.id }),
           pull.collect((err, results) => {
-            t.equal(results.length, 2)
+            t.equal(results.length, 3)
             t.end()
           })
         )
@@ -153,15 +149,13 @@ test('Encrypted', (t) => {
   )
 
   db.publish(content, (err, privateMsg) => {
-    db.onDrain(() => {
-      pull(
-        sbot.createHistoryStream({ id: keys.id, keys: false }),
-        pull.collect((err, results) => {
-          t.equal(results.length, 4)
-          t.equal(typeof results[3].content, 'string')
-          sbot.close(t.end)
-        })
-      )
-    })
+    pull(
+      sbot.createHistoryStream({ id: keys.id, keys: false }),
+      pull.collect((err, results) => {
+        t.equal(results.length, 4)
+        t.equal(typeof results[3].content, 'string')
+        sbot.close(t.end)
+      })
+    )
   })
 })

--- a/test/full-mentions.js
+++ b/test/full-mentions.js
@@ -48,30 +48,25 @@ test('getMessagesByMention', (t) => {
       db.publish(mentionMsg, (err) => {
         t.error(err, 'no err')
 
-        db.onDrain('fullMentions', () => {
-          const status = db.getStatus()
-          t.equal(status.indexes['fullMentions'], 780, 'index in sync')
+        db.query(
+          and(mentions(feedId)),
+          toCallback((err, results) => {
+            t.error(err, 'no err')
+            t.equal(results.length, 1)
+            t.equal(results[0].value.content.text, mentionFeed.text)
 
-          db.query(
-            and(mentions(feedId)),
-            toCallback((err, results) => {
-              t.error(err, 'no err')
-              t.equal(results.length, 1)
-              t.equal(results[0].value.content.text, mentionFeed.text)
-
-              db.query(
-                and(mentions(postMsg.key)),
-                toCallback((err2, results2) => {
-                  t.error(err2, 'no err')
-                  t.equal(results2.length, 1)
-                  t.equal(results2[0].value.content.text, mentionMsg.text)
-                  t.end()
-                  sbot.close()
-                })
-              )
-            })
-          )
-        })
+            db.query(
+              and(mentions(postMsg.key)),
+              toCallback((err2, results2) => {
+                t.error(err2, 'no err')
+                t.equal(results2.length, 1)
+                t.equal(results2[0].value.content.text, mentionMsg.text)
+                t.end()
+                sbot.close()
+              })
+            )
+          })
+        )
       })
     })
   })

--- a/test/migration.js
+++ b/test/migration.js
@@ -61,24 +61,27 @@ test('migrate moves msgs from old log to new log', (t) => {
     fromEvent('ssb:db2:migrate:progress', sbot),
     pull.filter((x) => x === 1),
     pull.take(1),
-    pull.drain(() => {
-      // we need to make sure async-flumelog has written the data
-      sbot.db.onDrain(() => {
+    // we need to make sure async-flumelog has written the data
+    pull.asyncMap((_, continueCb) =>
+      setTimeout(() => {
         t.true(
           fs.existsSync(path.join(dir, 'db2', 'log.bipf')),
           'migration done'
         )
-        sbot.db.query(
-          toCallback((err1, msgs) => {
-            t.error(err1, 'no err')
-            t.equal(msgs.length, TOTAL)
-            t.true(progressEventsReceived, 'progress events received')
-            sbot.close(() => {
-              t.end()
-            })
+        continueCb()
+      }, 1000)
+    ),
+    pull.drain(() => {
+      sbot.db.query(
+        toCallback((err1, msgs) => {
+          t.error(err1, 'no err')
+          t.equal(msgs.length, TOTAL)
+          t.true(progressEventsReceived, 'progress events received')
+          sbot.close(() => {
+            t.end()
           })
-        )
-      })
+        })
+      )
     })
   )
 })
@@ -102,46 +105,36 @@ test('migrate keeps new log synced with old log being updated', (t) => {
     pull.filter((x) => x === 1),
     pull.take(1),
     pull.drain(() => {
-      sbot.db.onDrain(() => {
-        t.true(
-          fs.existsSync(path.join(dir, 'db2', 'log.bipf')),
-          'migration done'
-        )
-        sbot.db.query(
-          toCallback((err1, msgs) => {
-            t.error(err1, '1st query suceeded')
-            t.equal(msgs.length, TOTAL, `${TOTAL} msgs`)
+      t.true(fs.existsSync(path.join(dir, 'db2', 'log.bipf')), 'migration done')
+      sbot.db.query(
+        toCallback((err1, msgs) => {
+          t.error(err1, '1st query suceeded')
+          t.equal(msgs.length, TOTAL, `${TOTAL} msgs`)
 
-            // This should run after the sbot.publish completes
-            pull(
-              fromEvent('ssb:db2:migrate:progress', sbot),
-              pull.filter((x) => x === 1),
-              pull.take(1),
-              pull.drain(() => {
-                sbot.db.onDrain(() => {
-                  sbot.db.query(
-                    toCallback((err3, msgs2) => {
-                      t.error(err3, '2nd query suceeded')
-                      t.equal(msgs2.length, TOTAL + 1, `${TOTAL + 1} msgs`)
-                      sbot.close(() => {
-                        t.end()
-                      })
-                    })
-                  )
+          // This should run after the sbot.publish completes
+          pull(
+            fromEvent('ssb:db2:migrate:progress', sbot),
+            pull.filter((x) => x === 1),
+            pull.take(1),
+            pull.drain(() => {
+              sbot.db.query(
+                toCallback((err3, msgs2) => {
+                  t.error(err3, '2nd query suceeded')
+                  t.equal(msgs2.length, TOTAL + 1, `${TOTAL + 1} msgs`)
+                  sbot.close(() => {
+                    t.end()
+                  })
                 })
-              })
-            )
+              )
+            })
+          )
 
-            sbot.publish(
-              { type: 'post', text: 'Extra post' },
-              (err2, posted) => {
-                t.error(err2, 'publish suceeded')
-                t.equals(posted.value.content.type, 'post', 'msg posted')
-              }
-            )
+          sbot.publish({ type: 'post', text: 'Extra post' }, (err2, posted) => {
+            t.error(err2, 'publish suceeded')
+            t.equals(posted.value.content.type, 'post', 'msg posted')
           })
-        )
-      })
+        })
+      )
     })
   )
 })

--- a/test/migration.js
+++ b/test/migration.js
@@ -62,16 +62,9 @@ test('migrate moves msgs from old log to new log', (t) => {
     pull.filter((x) => x === 1),
     pull.take(1),
     // we need to make sure async-flumelog has written the data
-    pull.asyncMap((_, continueCb) =>
-      setTimeout(() => {
-        t.true(
-          fs.existsSync(path.join(dir, 'db2', 'log.bipf')),
-          'migration done'
-        )
-        continueCb()
-      }, 1000)
-    ),
+    pull.asyncMap((_, cb) => sbot.db.log.onDrain(cb)),
     pull.drain(() => {
+      t.true(fs.existsSync(path.join(dir, 'db2', 'log.bipf')), 'migration done')
       sbot.db.query(
         toCallback((err1, msgs) => {
           t.error(err1, 'no err')

--- a/test/operators.js
+++ b/test/operators.js
@@ -292,12 +292,9 @@ test('live votesFor', (t) => {
             (result) => {
               if (i++ == 0) {
                 t.equal(result.key, v1.key)
-
-                setTimeout(() => {
-                  db.publish(voteMsg2, (err, v2) => {
-                    t.error(err, 'no err')
-                  })
-                }, 1000)
+                db.publish(voteMsg2, (err, v2) => {
+                  t.error(err, 'no err')
+                })
               } else {
                 t.equal(result.value.content.vote.value, -1)
                 sbot.close(t.end)

--- a/test/operators.js
+++ b/test/operators.js
@@ -39,17 +39,15 @@ test('execute and(type("post"), author(me))', (t) => {
   db.publish(post, (err, postMsg) => {
     t.error(err, 'no err')
 
-    db.onDrain('base', () => {
-      db.query(
-        and(type('post'), author(keys.id)),
-        toCallback((err2, msgs) => {
-          t.error(err2, 'no err2')
-          t.equal(msgs.length, 1)
-          t.equal(msgs[0].value.content.type, 'post')
-          t.end()
-        })
-      )
-    })
+    db.query(
+      and(type('post'), author(keys.id)),
+      toCallback((err2, msgs) => {
+        t.error(err2, 'no err2')
+        t.equal(msgs.length, 1)
+        t.equal(msgs[0].value.content.type, 'post')
+        t.end()
+      })
+    )
   })
 })
 
@@ -63,17 +61,15 @@ test('execute and(type("post"), isPrivate())', (t) => {
   db.publish(content, (err, postMsg) => {
     t.error(err, 'no err')
 
-    db.onDrain('base', () => {
-      db.query(
-        and(type('post'), isPrivate()),
-        toCallback((err2, msgs) => {
-          t.error(err2, 'no err2')
-          t.equal(msgs.length, 1)
-          t.equal(msgs[0].value.content.text, 'super secret')
-          t.end()
-        })
-      )
-    })
+    db.query(
+      and(type('post'), isPrivate()),
+      toCallback((err2, msgs) => {
+        t.error(err2, 'no err2')
+        t.equal(msgs.length, 1)
+        t.equal(msgs[0].value.content.text, 'super secret')
+        t.end()
+      })
+    )
   })
 })
 
@@ -86,17 +82,15 @@ test('execute isRoot()', (t) => {
       (err2) => {
         t.error(err2, 'no err2')
 
-        db.onDrain('base', () => {
-          db.query(
-            and(type('foo'), isRoot()),
-            toCallback((err3, msgs) => {
-              t.error(err3, 'no err3')
-              t.equal(msgs.length, 1)
-              t.equal(msgs[0].value.content.text, 'Testing root!')
-              t.end()
-            })
-          )
-        })
+        db.query(
+          and(type('foo'), isRoot()),
+          toCallback((err3, msgs) => {
+            t.error(err3, 'no err3')
+            t.equal(msgs.length, 1)
+            t.equal(msgs[0].value.content.text, 'Testing root!')
+            t.end()
+          })
+        )
       }
     )
   })
@@ -117,17 +111,15 @@ test('execute hasRoot(msgkey)', (t) => {
       db.publish(threadMsg1, (err) => {
         t.error(err, 'no err')
 
-        db.onDrain(() => {
-          db.query(
-            and(hasRoot(postMsg.key)),
-            toCallback((err, results) => {
-              t.error(err, 'no err')
-              t.equal(results.length, 1)
-              t.equal(results[0].value.content.text, threadMsg1.text)
-              t.end()
-            })
-          )
-        })
+        db.query(
+          and(hasRoot(postMsg.key)),
+          toCallback((err, results) => {
+            t.error(err, 'no err')
+            t.equal(results.length, 1)
+            t.equal(results[0].value.content.text, threadMsg1.text)
+            t.end()
+          })
+        )
       })
     })
   })
@@ -157,17 +149,15 @@ test('hasRoot() outputs encrypted replies too', (t) => {
       db.publish(threadMsg1, (err, privMsg) => {
         t.error(err, 'no err')
 
-        db.onDrain(() => {
-          db.query(
-            and(hasRoot(postMsg.key)),
-            toCallback((err, results) => {
-              t.error(err, 'no err')
-              t.equal(results.length, 1)
-              t.equal(results[0].value.content.text, 'encrypted reply')
-              t.end()
-            })
-          )
-        })
+        db.query(
+          and(hasRoot(postMsg.key)),
+          toCallback((err, results) => {
+            t.error(err, 'no err')
+            t.equal(results.length, 1)
+            t.equal(results[0].value.content.text, 'encrypted reply')
+            t.end()
+          })
+        )
       })
     })
   })
@@ -197,26 +187,24 @@ test('execute mentions(feedid) and mentions(msgkey)', (t) => {
       db.publish(mentionMsg, (err) => {
         t.error(err, 'no err')
 
-        db.onDrain(() => {
-          db.query(
-            and(mentions(feedId)),
-            toCallback((err, results) => {
-              t.error(err, 'no err')
-              t.equal(results.length, 1)
-              t.equal(results[0].value.content.text, mentionFeed.text)
+        db.query(
+          and(mentions(feedId)),
+          toCallback((err, results) => {
+            t.error(err, 'no err')
+            t.equal(results.length, 1)
+            t.equal(results[0].value.content.text, mentionFeed.text)
 
-              db.query(
-                and(mentions(postMsg.key)),
-                toCallback((err2, results2) => {
-                  t.error(err2, 'no err')
-                  t.equal(results2.length, 1)
-                  t.equal(results2[0].value.content.text, mentionMsg.text)
-                  t.end()
-                })
-              )
-            })
-          )
-        })
+            db.query(
+              and(mentions(postMsg.key)),
+              toCallback((err2, results2) => {
+                t.error(err2, 'no err')
+                t.equal(results2.length, 1)
+                t.equal(results2[0].value.content.text, mentionMsg.text)
+                t.end()
+              })
+            )
+          })
+        )
       })
     })
   })
@@ -252,18 +240,16 @@ test('execute votesFor(msgkey)', (t) => {
       db.publish(voteMsg2, (err, v2) => {
         t.error(err, 'no err')
 
-        db.onDrain(() => {
-          db.query(
-            and(votesFor(postMsg.key)),
-            toCallback((err, results) => {
-              t.error(err, 'no err')
-              t.equal(results.length, 2)
-              t.equal(results[0].key, v1.key)
-              t.equal(results[1].key, v2.key)
-              t.end()
-            })
-          )
-        })
+        db.query(
+          and(votesFor(postMsg.key)),
+          toCallback((err, results) => {
+            t.error(err, 'no err')
+            t.equal(results.length, 2)
+            t.equal(results[0].key, v1.key)
+            t.equal(results[1].key, v2.key)
+            t.end()
+          })
+        )
       })
     })
   })
@@ -296,31 +282,31 @@ test('live votesFor', (t) => {
     db.publish(voteMsg1, (err, v1) => {
       t.error(err, 'no err')
 
-      db.onDrain(() => {
-        let i = 0
-        pull(
-          db.query(
-            and(votesFor(postMsg.key)),
-            live(),
-            toPullStream(),
-            pull.drain(
-              (result) => {
-                if (i++ == 0) {
-                  t.equal(result.key, v1.key)
+      let i = 0
+      pull(
+        db.query(
+          and(votesFor(postMsg.key)),
+          live(),
+          toPullStream(),
+          pull.drain(
+            (result) => {
+              if (i++ == 0) {
+                t.equal(result.key, v1.key)
 
+                setTimeout(() => {
                   db.publish(voteMsg2, (err, v2) => {
                     t.error(err, 'no err')
                   })
-                } else {
-                  t.equal(result.value.content.vote.value, -1)
-                  sbot.close(t.end)
-                }
-              },
-              () => {}
-            )
+                }, 1000)
+              } else {
+                t.equal(result.value.content.vote.value, -1)
+                sbot.close(t.end)
+              }
+            },
+            () => {}
           )
         )
-      })
+      )
     })
   })
 })


### PR DESCRIPTION
Implementation comments are inline in the code

### Performance before, no EBT index

```
➜  ssb-db2 git:(master) rm -rf ~/.ssb/db2/indexes

➜  ssb-db2 git:(master) node gitignored/example.js
There are 15 messages
duration: 22285ms

➜  ssb-db2 git:(master) node gitignored/example.js
There are 15 messages
duration: 419ms

➜  ssb-db2 git:(master) node gitignored/example.js
There are 15 messages
duration: 401ms

➜  ssb-db2 git:(master) node gitignored/example.js
There are 15 messages
duration: 402ms

➜  ssb-db2 git:(master) du -h ~/.ssb/db2/indexes
7,6M	/home/staltz/.ssb/db2/indexes/base
29M	/home/staltz/.ssb/db2/indexes
```

### Performance after, no EBT index


```
➜  ssb-db2 git:(ondrain) rm -rf ~/.ssb/db2/indexes

➜  ssb-db2 git:(ondrain) node gitignored/example.js
There are 15 messages
duration: 20885ms

➜  ssb-db2 git:(ondrain) node gitignored/example.js
There are 15 messages
duration: 464ms

➜  ssb-db2 git:(ondrain) node gitignored/example.js
There are 15 messages
duration: 407ms

➜  ssb-db2 git:(ondrain) node gitignored/example.js
There are 15 messages
duration: 406ms

➜  ssb-db2 git:(ondrain) du -h ~/.ssb/db2/indexes
7,6M /home/staltz/.ssb/db2/indexes/base
29M  /home/staltz/.ssb/db2/indexes
```
