### PR TITLE
Validate latest block in log on load

### DIFF
--- a/log.js
+++ b/log.js
@@ -7,6 +7,14 @@ module.exports = function (dir, config, private) {
 
   const log = OffsetLog(newLogPath(dir), {
     blockSize: BLOCK_SIZE,
+    validateRecord: (d) => {
+      try {
+        bipf.decode(d, 0)
+        return true
+      } catch (ex) {
+        return false
+      }
+    },
   })
 
   log.add = function (id, msg, cb) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:arj03/ssb-db2.git"
   },
   "dependencies": {
-    "async-flumelog": "^1.0.10",
+    "async-flumelog": "^1.1.0",
     "atomically-universal": "^0.1.0",
     "binary-search-bounds": "^2.0.4",
     "bipf": "~1.4.0",


### PR DESCRIPTION
This uses the new functionality in async-flumelog to better guard against file corruption by trying to fix the latest block on load