### PR TITLE
Better documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,6 @@ sbot.db2migrate.start()
 
 Get a particular message by message id.
 
-### publish(msg, cb)
-
-Convinience method for validating and adding a message to the database
-written by the feed running the secret-stack.
-
 ### del(msgId, cb)
 
 Delete a specific message given the message id from the
@@ -226,23 +221,28 @@ this method unless you know exactly what you are doing.
 Delete all messages of a specific feedId. Compared to `del` this
 method is safe to use.
 
+### publish(msg, cb)
+
+Convinience method for validating and adding a message to the database
+written by the feed running the secret-stack.
+
 ### add(msg, cb)
 
-Add a raw message (without id and timestamp) to the database. In the
-callback will be the stored message (id, timestamp, value = original
-message) or err. Please note this does not validate the message.
+Validate and add a raw message (without id and timestamp) to the
+database. In the callback will be the stored message (id, timestamp,
+value = original message) or err.
 
-### validateAndAdd(msg, cb)
+### addOOOStrictOrder(msg, cb)
 
-Works like `add` except the message will be validated first. If the
-author is not yet known, the message is validated without checking if
-the previous link is correct, otherwise normal validation. This makes
-it possible to use for partial replication.
+Works quite similar to `add`. If the author is not yet known, the
+message is validated without checking if the previous link is correct,
+otherwise normal validation. This makes it possible to use for partial
+replication to add say latest 25 messages from a feed.
 
-### validateAndAddOOO(msg, cb)
+### addOOO(msg, cb)
 
-Same as `validateAndAdd` except this will never check the previous
-link. Useful for partial replication.
+Validate without checking the previous link and add to db. Useful for
+partial replication.
 
 ### getStatus
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ const SecretStack = require('secret-stack')
 const caps = require('ssb-caps')
 const {and, type, author, toCallback} = require('ssb-db2/operators')
 
-const sbot = SecretStack({appKey: caps.shs})
+const sbot = SecretStack({ caps })
   .use(require('ssb-db2'))
-  .call(null, {})
+  .call(null, { path: './' })
 
 sbot.db.query(
   and(type('post')),
@@ -50,9 +50,9 @@ const SecretStack = require('secret-stack')
 const caps = require('ssb-caps')
 const {query, and, type, author, mentions, toCallback} = require('ssb-db2/operators')
 
-const sbot = SecretStack({appKey: caps.shs})
+const sbot = SecretStack({ caps })
   .use(require('ssb-db2'))
-  .call(null, {})
+  .call(null, { path: './' })
 
 sbot.db.query(
   and(type('post'), mentions(alice.id))),
@@ -87,10 +87,10 @@ const caps = require('ssb-caps')
 const {query, and, type, author, toCallback} = require('ssb-db2/operators')
 const mentions = require('ssb-db2/operators/full-mentions')
 
-const sbot = SecretStack({appKey: caps.shs})
+const sbot = SecretStack({ caps })
   .use(require('ssb-db2'))
   .use(require('ssb-db2/full-mentions')) // include index
-  .call(null, {})
+  .call(null, { path: './' })
 
 sbot.db.query(
   and(type('post'), mentions(alice.id))),
@@ -109,7 +109,7 @@ including legacy replication, ebt and publish. They can be loaded as:
 ```js
 const SecretStack = require('secret-stack')
 
-const sbot = SecretStack({appKey: caps.shs})
+const sbot = SecretStack({ caps })
   .use(require('ssb-db2'))
   .use(require('ssb-db2/compat')) // include all compatibility plugins
   .call(null, {})
@@ -120,7 +120,7 @@ or specifically:
 ```js
 const SecretStack = require('secret-stack')
 
-const sbot = SecretStack({appKey: caps.shs})
+const sbot = SecretStack({ caps })
   .use(require('ssb-db2'))
   .use(require('ssb-db2/compat/db')) // basic db compatibility
   .use(require('ssb-db2/compat/history-stream')) // legacy replication
@@ -147,7 +147,7 @@ const config = {
   }
 }
 
-const sbot = SecretStack({appKey: caps.shs})
+const sbot = SecretStack({ caps })
   .use(require('ssb-db2'))
   .use(require('ssb-db2/compat'))
   .call(null, config)
@@ -166,7 +166,7 @@ Note, it is acceptable to load both ssb-db and ssb-db2 plugins, the
 system will still function correctly and migrate correctly:
 
 ```js
-const sbot = SecretStack({appKey: caps.shs})
+const sbot = SecretStack({ caps })
   .use(require('ssb-db'))
   .use(require('ssb-db2'))
   .use(require('ssb-db2/compat'))

--- a/README.md
+++ b/README.md
@@ -223,12 +223,12 @@ method is safe to use.
 
 ### publish(msg, cb)
 
-Convinience method for validating and adding a message to the database
+Convenience method for validating and adding a message to the database
 written by the feed running the secret-stack.
 
 ### add(msg, cb)
 
-Validate and add a raw message (without id and timestamp) to the
+Validate and add a message value (without id and timestamp) to the
 database. In the callback will be the stored message (id, timestamp,
 value = original message) or err.
 

--- a/db.js
+++ b/db.js
@@ -113,7 +113,7 @@ exports.init = function (sbot, config) {
     )
   }
 
-  function add(msg, cb) {
+  function rawAdd(msg, cb) {
     const guard = guardAgainstDuplicateLogs('add()')
     if (guard) return cb(guard)
 
@@ -136,13 +136,60 @@ exports.init = function (sbot, config) {
     })
   }
 
+  function add(msg, cb) {
+    const guard = guardAgainstDuplicateLogs('add()')
+    if (guard) return cb(guard)
+
+    try {
+      state = validate.append(state, hmac_key, msg)
+      if (state.error) return cb(state.error)
+      rawAdd(msg, cb)
+    } catch (ex) {
+      return cb(ex)
+    }
+  }
+
+  function addOOO(msg, cb) {
+    const guard = guardAgainstDuplicateLogs('validateAndAddOOO()')
+    if (guard) return cb(guard)
+
+    try {
+      let oooState = validate.initial()
+      validate.appendOOO(oooState, hmac_key, msg)
+
+      if (oooState.error) return cb(oooState.error)
+
+      rawAdd(msg, cb)
+    } catch (ex) {
+      return cb(ex)
+    }
+  }
+
+  function addOOOStrictOrder(msg, cb) {
+    const guard = guardAgainstDuplicateLogs('validateAndAddOOOStrictOrder()')
+    if (guard) return cb(guard)
+
+    const knownAuthor = msg.author in state.feeds
+
+    try {
+      if (!knownAuthor) state = validate.appendOOO(state, hmac_key, msg)
+      else state = validate.append(state, hmac_key, msg)
+
+      if (state.error) return cb(state.error)
+
+      rawAdd(msg, cb)
+    } catch (ex) {
+      return cb(ex)
+    }
+  }
+
   function publish(msg, cb) {
     const guard = guardAgainstDuplicateLogs('publish()')
     if (guard) return cb(guard)
 
     state.queue = []
     state = validate.appendNew(state, null, config.keys, msg, Date.now())
-    add(state.queue[0].value, (err, data) => {
+    rawAdd(state.queue[0].value, (err, data) => {
       post.set(data)
       cb(err, data)
     })
@@ -183,40 +230,6 @@ exports.init = function (sbot, config) {
         })
       )
     })
-  }
-
-  function validateAndAddOOO(msg, cb) {
-    const guard = guardAgainstDuplicateLogs('validateAndAddOOO()')
-    if (guard) return cb(guard)
-
-    try {
-      let oooState = validate.initial()
-      validate.appendOOO(oooState, hmac_key, msg)
-
-      if (oooState.error) return cb(oooState.error)
-
-      add(msg, cb)
-    } catch (ex) {
-      return cb(ex)
-    }
-  }
-
-  function validateAndAdd(msg, cb) {
-    const guard = guardAgainstDuplicateLogs('validateAndAdd()')
-    if (guard) return cb(guard)
-
-    const knownAuthor = msg.author in state.feeds
-
-    try {
-      if (!knownAuthor) state = validate.appendOOO(state, hmac_key, msg)
-      else state = validate.append(state, hmac_key, msg)
-
-      if (state.error) return cb(state.error)
-
-      add(msg, cb)
-    } catch (ex) {
-      return cb(ex)
-    }
   }
 
   function getStatus() {
@@ -385,13 +398,13 @@ exports.init = function (sbot, config) {
   return {
     // API:
     get,
-    add,
-    publish,
     query,
     del,
     deleteFeed,
-    validateAndAdd,
-    validateAndAddOOO,
+    add,
+    publish,
+    addOOO,
+    addOOOStrictOrder,
     getStatus,
 
     // needed primarily internally by other plugins in this project:

--- a/db.js
+++ b/db.js
@@ -37,8 +37,8 @@ exports.manifest = {
   publish: 'async',
   del: 'async',
   deleteFeed: 'async',
-  validateAndAdd: 'async',
-  validateAndAddOOO: 'async',
+  addOOO: 'async',
+  addOOOStrictOrder: 'async',
   getStatus: 'sync',
 
   // `query` should be `sync`, but secret-stack is automagically converting it
@@ -150,7 +150,7 @@ exports.init = function (sbot, config) {
   }
 
   function addOOO(msg, cb) {
-    const guard = guardAgainstDuplicateLogs('validateAndAddOOO()')
+    const guard = guardAgainstDuplicateLogs('addOOO()')
     if (guard) return cb(guard)
 
     try {
@@ -166,7 +166,7 @@ exports.init = function (sbot, config) {
   }
 
   function addOOOStrictOrder(msg, cb) {
-    const guard = guardAgainstDuplicateLogs('validateAndAddOOOStrictOrder()')
+    const guard = guardAgainstDuplicateLogs('addOOOStrictOrder()')
     if (guard) return cb(guard)
 
     const knownAuthor = msg.author in state.feeds

--- a/db.js
+++ b/db.js
@@ -114,9 +114,6 @@ exports.init = function (sbot, config) {
   }
 
   function rawAdd(msg, cb) {
-    const guard = guardAgainstDuplicateLogs('add()')
-    if (guard) return cb(guard)
-
     const id = getId(msg)
 
     /*

--- a/test/validate.js
+++ b/test/validate.js
@@ -93,19 +93,19 @@ test('Raw feed with unused type + ooo', (t) => {
     Date.now() + 5
   )
 
-  db.validateAndAdd(state.queue[2].value, (err) => {
+  db.addOOOStrictOrder(state.queue[2].value, (err) => {
     t.error(err, 'no err')
 
-    db.validateAndAdd(state.queue[3].value, (err) => {
+    db.addOOOStrictOrder(state.queue[3].value, (err) => {
       t.error(err, 'no err')
 
-      db.validateAndAdd(state.queue[4].value, (err) => {
+      db.addOOOStrictOrder(state.queue[4].value, (err) => {
         t.error(err, 'no err')
 
-        db.validateAndAdd(state.queue[5].value, (err) => {
+        db.addOOOStrictOrder(state.queue[5].value, (err) => {
           t.error(err, 'no err')
 
-          db.validateAndAddOOO(state.queue[0].value, (err, oooMsg) => {
+          db.addOOO(state.queue[0].value, (err, oooMsg) => {
             t.error(err, 'no err')
             t.equal(oooMsg.value.content.text, 'test1', 'text correct')
 
@@ -117,7 +117,8 @@ test('Raw feed with unused type + ooo', (t) => {
   })
 })
 
-// we might get some messages from an earlier thread, and then get the latest 25 messages from the user
+// we might get some messages from an earlier thread, and then get the
+// latest 25 messages from the user
 test('Add with holes', (t) => {
   let state = validate.initial()
   const keys = ssbKeys.generate()
@@ -144,10 +145,10 @@ test('Add with holes', (t) => {
     Date.now() + 2
   ) // start
 
-  db.validateAndAdd(state.queue[0].value, (err) => {
+  db.addOOOStrictOrder(state.queue[0].value, (err) => {
     t.error(err, 'no err')
 
-    db.validateAndAddOOO(state.queue[2].value, (err, msg) => {
+    db.addOOO(state.queue[2].value, (err, msg) => {
       t.error(err, 'no err')
       t.equal(msg.value.content.text, 'test3', 'text correct')
       t.end()
@@ -174,13 +175,13 @@ test('Add same message twice', (t) => {
     Date.now() + 1
   )
 
-  db.validateAndAdd(state.queue[0].value, (err) => {
+  db.add(state.queue[0].value, (err) => {
     t.error(err, 'no err')
 
-    db.validateAndAdd(state.queue[1].value, (err) => {
+    db.add(state.queue[1].value, (err) => {
       t.error(err, 'no err')
 
-      db.validateAndAdd(state.queue[1].value, (err) => {
+      db.add(state.queue[1].value, (err) => {
         t.ok(err, 'Should fail to add')
         t.end()
       })
@@ -207,10 +208,10 @@ test('Strict order basic case', (t) => {
     Date.now() + 1
   )
 
-  db.validateAndAdd(state.queue[0].value, (err) => {
+  db.addOOOStrictOrder(state.queue[0].value, (err) => {
     t.error(err, 'no err')
 
-    db.validateAndAdd(state.queue[1].value, (err) => {
+    db.addOOOStrictOrder(state.queue[1].value, (err) => {
       t.error(err, 'no err')
       t.end()
     })
@@ -243,10 +244,47 @@ test('Strict order fail case', (t) => {
     Date.now() + 2
   )
 
-  db.validateAndAdd(state.queue[0].value, (err) => {
+  db.addOOOStrictOrder(state.queue[0].value, (err) => {
     t.error(err, 'no err')
 
-    db.validateAndAdd(state.queue[2].value, (err) => {
+    db.addOOOStrictOrder(state.queue[2].value, (err) => {
+      t.ok(err, 'Should fail to add')
+
+      t.end()
+    })
+  })
+})
+
+test('add fail case', (t) => {
+  let state = validate.initial()
+  const keys = ssbKeys.generate()
+
+  state = validate.appendNew(
+    state,
+    null,
+    keys,
+    { type: 'post', text: 'test1' },
+    Date.now()
+  )
+  state = validate.appendNew(
+    state,
+    null,
+    keys,
+    { type: 'post', text: 'test2' },
+    Date.now() + 1
+  )
+  state = validate.appendNew(
+    state,
+    null,
+    keys,
+    { type: 'post', text: 'test3' },
+    Date.now() + 2
+  )
+
+  db.add(state.queue[0].value, (err) => {
+    t.error(err, 'no err')
+
+    db.add(state.queue[2].value, (err) => {
       t.ok(err, 'Should fail to add')
 
       sbot.close(t.end)


### PR DESCRIPTION
I wanted to add documentation to our methods and started looking at add. I never really used the method in ssb-browser only internally, but noticed that in ssb-db it validates. I didn't want to change for no reason, so moved some things around a bit and made it so that `add` works like in ssb-db. I still want to have a look at #7, but for now this should be good enough.