### PR TITLE
improve performance of migrate plugin

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -91,7 +91,7 @@ function inefficientFindMigratedOffset(newLog, oldLog, cb) {
     if (err) return cb(err) // TODO: might need an explain() here
     if (!msgCountNewLog) return cb(null, -1)
 
-    let result = null
+    let result = -1
     pull(
       oldLog.getStream({ gte: 0 }),
       pull.take(msgCountNewLog),


### PR DESCRIPTION
For issue #95. I tested this in my production Manyverse and it gave a significant improvement. Time between "press like" and "like appears" dropped from (approximately) 45 seconds to (approximately) 2 seconds.

This PR has a somewhat hacky solution. It basically expects `sbot.get(msgkey, cb)` to call the `cb` with 3 arguments, `cb(err, msg, offset)`. If the 3rd argument is undefined, migrate plugin fallsback to what it was doing before: scan the new log, counting the records, then scan the old log.

If `sbot.get` is patched to provide the offset in the third arg, this improves performance a lot. Otherwise, it's the same. I intend to ship a hacky `ssb-db` to provide the third arg. We can work in the `ssb-db` repo to add this support, or add another API, either way, we can rather easily get rid of the hacky idea by improving `ssb-db` APIs.