### PR TITLE
benchmark: dont migrate during initial indexing

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -83,8 +83,6 @@ test('initial indexing', (t) => {
     .use(require('../'))
     .call(null, { keys, path: dir })
 
-  sbot.db2migrate.start()
-
   const start = Date.now()
   sbot.db.query(
     and(type('post')),


### PR DESCRIPTION
We're using the "inefficient mode" of migrate plugin because https://github.com/ssbc/ssb-db/pull/319 is not yet deployed, so the `initial indexing` benchmark is disturbed by migrate running in the background (it's not actually migrating anything, it's just scanning the entire old log). Once we have efficient mode for migrate, then we *could* keep this line of code in, but anyway it doesn't make sense to keep it in.