### PR TITLE
benchmark: two different types of migrate

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -9,6 +9,8 @@ const caps = require('ssb-caps')
 const ssbKeys = require('ssb-keys')
 const pull = require('pull-stream')
 const fromEvent = require('pull-stream-util/from-event')
+const DeferredPromise = require('p-defer')
+const sleep = require('util').promisify(setTimeout)
 const { and, type, descending, paginate, toCallback } = require('../operators')
 
 const dir = '/tmp/ssb-db2-benchmark'
@@ -21,7 +23,6 @@ const skipCreate = process.argv[2] === 'noCreate'
 if (!skipCreate) {
   rimraf.sync(dir)
   mkdirp.sync(dir)
-  fs.appendFileSync(reportPath, '## Benchmark results\n\n')
 
   const SEED = 'sloop'
   const MESSAGES = 100000
@@ -39,23 +40,33 @@ if (!skipCreate) {
       t.pass(`messages = ${MESSAGES}`)
       t.pass(`authors = ${AUTHORS}`)
       t.true(fs.existsSync(oldLogPath), 'log.offset was created')
+      fs.appendFileSync(reportPath, '## Benchmark results\n\n')
+      fs.appendFileSync(reportPath, '| Part | Duration |\n|---|---|\n')
       t.end()
     })
   })
 }
 
-test('reset db2', (t) => {
+test('migration (using ssb-db)', async (t) => {
   rimraf.sync(db2Path)
   t.pass('delete db2 folder to start clean')
-  t.end()
-})
 
-test('migration', (t) => {
   const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
   const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('ssb-db'))
     .use(require('../migrate'))
     .call(null, { keys, path: dir })
 
+  while (true) {
+    const { current, target } = sbot.progress().indexes
+    if (current === target) break
+    else await sleep(500)
+  }
+  t.pass('ssb-db has finished indexing')
+
+  await sleep(500) // some silence to make it easier to read the CPU profiler
+
+  const ended = DeferredPromise()
   const start = Date.now()
   sbot.db2migrate.start()
 
@@ -63,27 +74,67 @@ test('migration', (t) => {
     fromEvent('ssb:db2:migrate:progress', sbot),
     pull.filter((progress) => progress === 1),
     pull.take(1),
-    pull.drain(() => {
+    pull.drain(async () => {
       const duration = Date.now() - start
       t.pass(`duration: ${duration}ms`)
-      fs.appendFileSync(reportPath, `- Migration: ${duration}ms\n`)
-      // wait for new log FS writes to finalize
-      setTimeout(() => {
-        sbot.close(() => {
-          t.end()
-        })
-      }, 2000)
+      fs.appendFileSync(
+        reportPath,
+        `| Migration (using ssb-db) | ${duration}ms |\n`
+      )
+      await sleep(2000) // wait for new log FS writes to finalize
+      sbot.close(() => {
+        ended.resolve()
+      })
     })
   )
+
+  await ended.promise
 })
 
-test('initial indexing', (t) => {
+test('migration (alone)', async (t) => {
+  rimraf.sync(db2Path)
+  t.pass('delete db2 folder to start clean')
+
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../migrate'))
+    .call(null, { keys, path: dir })
+
+  await sleep(500) // some silence to make it easier to read the CPU profiler
+
+  const ended = DeferredPromise()
+  const start = Date.now()
+  sbot.db2migrate.start()
+
+  pull(
+    fromEvent('ssb:db2:migrate:progress', sbot),
+    pull.filter((progress) => progress === 1),
+    pull.take(1),
+    pull.drain(async () => {
+      const duration = Date.now() - start
+      t.pass(`duration: ${duration}ms`)
+      fs.appendFileSync(reportPath, `| Migration (alone) | ${duration}ms |\n`)
+      await sleep(2000) // wait for new log FS writes to finalize
+      sbot.close(() => {
+        ended.resolve()
+      })
+    })
+  )
+
+  await ended.promise
+})
+
+test('initial indexing', async (t) => {
   const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
   const sbot = SecretStack({ appKey: caps.shs })
     .use(require('../'))
     .call(null, { keys, path: dir })
 
+  await sleep(500) // some silence to make it easier to read the CPU profiler
+
+  const ended = DeferredPromise()
   const start = Date.now()
+
   sbot.db.query(
     and(type('post')),
     descending(),
@@ -96,10 +147,12 @@ test('initial indexing', (t) => {
       if (!results[0].value.content.text.includes('LATESTMSG'))
         t.fail('should have LATESTMSG')
       t.pass(`duration: ${duration}ms`)
-      fs.appendFileSync(reportPath, `- Initial indexing: ${duration}ms\n`)
+      fs.appendFileSync(reportPath, `| Initial indexing | ${duration}ms |\n`)
       sbot.close(() => {
-        t.end()
+        ended.resolve()
       })
     })
   )
+
+  await ended.promise
 })

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "rimraf": "^3.0.2",
     "secret-stack": "6.3.1",
     "ssb-caps": "1.1.0",
-    "ssb-db": "20.3.0",
+    "ssb-db": "20.4.0",
     "ssb-fixtures": "2.2.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.1"


### PR DESCRIPTION
A bunch of updates:

- Benchmark migrate operating alone (no db2, no db1)
- Benchmark migrate operating with db1, using its APIs
- Report in markdown table, not a markdown list
- Add some setTimeout 500ms to create some "silence" and make it easier to detect what is what in the Chrome profiler
- Use async/await to manage all these timeouts more sanely
- The DeferredPromise is unfortunate, but when you use `async (t) => {` with Tape, it ends the test once it reaches the end of the function, I needed a way to prevent that