### PR TITLE
Always keep track of latest offset

### DIFF
--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -54,7 +54,8 @@ module.exports = function (
   function onData(record, isLive) {
     // maybe check if for us!
     const unwritten = handleData(record, processed)
-    if (unwritten > 0) unWrittenOffset = record.offset
+    if (isLive && unwritten > 0) unWrittenOffset = record.offset
+    else unWrittenOffset = record.offset
     processed++
 
     if (unwritten > chunkSize || isLive) writeBatch(() => {})

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -1,5 +1,6 @@
 const Obv = require('obz')
 const Level = require('level')
+const debounce = require('lodash.debounce')
 const path = require('path')
 const Debug = require('debug')
 const DeferredPromise = require('p-defer')
@@ -51,14 +52,15 @@ module.exports = function (
     } else cb()
   }
 
+  const liveWriteBatch = debounce(writeBatch, 250)
+
   function onData(record, isLive) {
-    // maybe check if for us!
     const unwritten = handleData(record, processed)
-    if (isLive && unwritten > 0) unWrittenOffset = record.offset
-    else unWrittenOffset = record.offset
+    unWrittenOffset = record.offset
     processed++
 
-    if (unwritten > chunkSize || isLive) writeBatch(() => {})
+    if (unwritten > chunkSize) writeBatch(() => {})
+    else if (isLive) liveWriteBatch(() => {})
   }
 
   level.get(META, { valueEncoding: 'json' }, (err, data) => {


### PR DESCRIPTION
As it is now, when the normal log finishes processing, all indexes will get a [write](https://github.com/ssb-ngi-pointer/ssb-db2/blob/05a7779953c22fae7846c05e113d5fb16b022c28/db.js#L263). If an index doesn't write something for each message, lets say its only interested in a particular type, then the last write might not write the final offset which means that you can't do something like onDrain on that index. Furthermore when you restart the app, it has to go through all those messages again it just checked. In the live case we have the same problem, but here we don't want to write for each message so we debounce the write a bit.