### PR TITLE
some operators use useMap and prefix

### DIFF
--- a/operators/index.js
+++ b/operators/index.js
@@ -47,6 +47,7 @@ function votesFor(msgKey) {
     type('vote'),
     equal(seekVoteLink, msgKey, {
       prefix: 32,
+      useMap: true,
       indexType: 'value_content_vote_link',
     })
   )()
@@ -57,6 +58,7 @@ function contact(feedId) {
     type('contact'),
     equal(seekContact, feedId, {
       prefix: 32,
+      useMap: true,
       indexType: 'value_content_contact',
     })
   )()
@@ -72,6 +74,7 @@ function mentions(key) {
 function hasRoot(msgKey) {
   return equal(seekRoot, msgKey, {
     prefix: 32,
+    useMap: true,
     indexType: 'value_content_root',
   })
 }
@@ -79,6 +82,7 @@ function hasRoot(msgKey) {
 function hasFork(msgKey) {
   return equal(seekFork, msgKey, {
     prefix: 32,
+    useMap: true,
     indexType: 'value_content_fork',
   })
 }
@@ -86,6 +90,7 @@ function hasFork(msgKey) {
 function hasBranch(msgKey) {
   return equal(seekBranch, msgKey, {
     prefix: 32,
+    useMap: true,
     indexType: 'value_content_branch',
   })
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "fastintcompression": "0.0.4",
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
-    "jitdb": "^1.0.5",
+    "jitdb": "^1.1.0",
     "level": "^6.0.1",
     "lodash.debounce": "^4.0.8",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
Before and after of the perf benchmarks:

```diff
  migration (using ssb-db)

    ✔ delete db2 folder to start clean
    ✔ ssb-db has finished indexing
-   ✔ duration: 2816ms
+   ✔ duration: 2870ms
    fallback to close

  migration (alone)

    ✔ delete db2 folder to start clean
-   ✔ duration: 2705ms
+   ✔ duration: 2722ms

  initial indexing

    ✔ null
-   ✔ duration: 2008ms
+   ✔ duration: 2043ms

  setup

  key one initial
-   ✔ duration: 454ms
+   ✔ duration: 464ms

  key two
-   ✔ duration: 19ms
+   ✔ duration: 20ms

  key one again
-   ✔ duration: 14ms
+   ✔ duration: 15ms

  latest root posts
-   ✔ duration: 371ms
+   ✔ duration: 364ms

  latest posts
-   ✔ duration: 29ms
+   ✔ duration: 32ms

  votes one initial
-   ✔ duration: 355ms
+   ✔ duration: 383ms

  votes again
-   ✔ duration: 11ms
+   ✔ duration: 0ms

  hasRoot
-   ✔ duration: 302ms
+   ✔ duration: 294ms

  hasRoot again
-   ✔ duration: 12ms
+   ✔ duration: 0ms

  author one posts
-   ✔ duration: 248ms
+   ✔ duration: 249ms

  author two posts
-   ✔ duration: 61ms
+   ✔ duration: 66ms

  teardown

  total:     18
  passing:   18
  duration:  15.3s
```