### PR TITLE
emit event ssb:db2:indexing:progress

### DIFF
--- a/db.js
+++ b/db.js
@@ -86,7 +86,7 @@ exports.init = function (sbot, config) {
   // Crunch stats numbers to produce one number for the "indexing" progress
   status.obv((stats) => {
     const logSize = Math.max(1, stats.log) // 1 prevents division by zero
-    const nums = Object.values(stats.jit).concat(Object.values(stats.indexes))
+    const nums = Object.values(stats.indexes)
     const N = Math.max(1, nums.length) // 1 prevents division by zero
     const progress = Math.min(
       nums

--- a/db.js
+++ b/db.js
@@ -83,6 +83,21 @@ exports.init = function (sbot, config) {
     stateFeedsReady.resolve()
   })
 
+  // Crunch stats numbers to produce one number for the "indexing" progress
+  status.obv((stats) => {
+    const logSize = Math.max(1, stats.log) // 1 prevents division by zero
+    const nums = Object.values(stats.jit).concat(Object.values(stats.indexes))
+    const N = Math.max(1, nums.length) // 1 prevents division by zero
+    const progress = Math.min(
+      nums
+        .map((offset) => Math.max(0, offset)) // avoid -1 numbers
+        .map((offset) => offset / logSize) // this index's progress
+        .reduce((acc, x) => acc + x, 0) / N, // avg = (sum of all progress) / N
+      1 // never go above 1
+    )
+    sbot.emit('ssb:db2:indexing:progress', progress)
+  })
+
   function guardAgainstDuplicateLogs(methodName) {
     if (sbot.db2migrate && sbot.db2migrate.doesOldLogExist()) {
       return new Error(


### PR DESCRIPTION
Similar to `ssb:db2:migrate:progress`. I thought that this number crunching would be likely needed in many apps, so better to put it here. If people want more precise numbers, per index, they can use `getStatus`.