### PR TITLE
add test for hookable createHistoryStream

### DIFF
--- a/compat/history-stream.js
+++ b/compat/history-stream.js
@@ -1,6 +1,7 @@
 const pull = require('pull-stream')
 const pullCont = require('pull-cont')
 const ref = require('ssb-ref')
+const Hookable = require('hoox')
 const { author } = require('../operators')
 const { reEncrypt } = require('../indexes/private')
 
@@ -15,7 +16,7 @@ exports.permissions = {
 }
 
 exports.init = function (sbot, config) {
-  sbot.createHistoryStream = function (opts) {
+  sbot.createHistoryStream = Hookable(function createHistoryStream(opts) {
     // default values
     const sequence = opts.sequence || opts.seq || 0
     const limit = opts.limit
@@ -67,7 +68,7 @@ exports.init = function (sbot, config) {
         })
       })
     )
-  }
+  })
 
   return {}
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "fastintcompression": "0.0.4",
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
+    "hoox": "0.0.1",
     "jitdb": "^1.3.1",
     "level": "^6.0.1",
     "lodash.debounce": "^4.0.8",

--- a/test/createHistoryStream.js
+++ b/test/createHistoryStream.js
@@ -159,3 +159,19 @@ test('Encrypted', (t) => {
     )
   })
 })
+
+test('should be hookable', (t) => {
+  let hookCalled = false
+  sbot.createHistoryStream.hook(function (fn, args) {
+    hookCalled = true
+    return fn.call(null, args[0])
+  })
+
+  pull(
+    sbot.createHistoryStream({ id: 'wat', limit: 1 }),
+    pull.collect(() => {
+      t.true(hookCalled)
+      t.end()
+    })
+  )
+})


### PR DESCRIPTION
1st adds failing test, 2nd commit fix.

We need this because ssb-replicate/legacy does a hook on the history stream.