### PR TITLE
report full memory usage in benchmarks

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -63,7 +63,7 @@ if (!skipCreate) {
 
 let maxRAM = 0
 function updateMaxRAM() {
-  maxRAM = Math.max(maxRAM, process.memoryUsage().heapTotal)
+  maxRAM = Math.max(maxRAM, process.memoryUsage().rss)
 }
 
 test('migration (using ssb-db)', async (t) => {

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -61,9 +61,22 @@ if (!skipCreate) {
   })
 }
 
-let maxRAM = 0
+let maxRAMrss = 0
+let maxRAMheap = 0
 function updateMaxRAM() {
-  maxRAM = Math.max(maxRAM, process.memoryUsage().rss)
+  const memUsage = process.memoryUsage()
+  maxRAMrss = Math.max(maxRAMrss, memUsage.rss)
+  maxRAMheap = Math.max(maxRAMheap, memUsage.heapUsed)
+}
+
+function toMB(bytes) {
+  return (bytes / 1000 / 1000).toFixed(2)
+}
+
+function reportMem() {
+  const rss = toMB(maxRAMrss)
+  const heap = toMB(maxRAMheap)
+  return `${rss} MB = ${heap} MB + etc`
 }
 
 test('migration (using ssb-db)', async (t) => {
@@ -101,6 +114,7 @@ test('migration (using ssb-db)', async (t) => {
         `| Migration (using ssb-db) | ${duration}ms |\n`
       )
       updateMaxRAM()
+      global.gc()
       await sleep(2000) // wait for new log FS writes to finalize
       sbot.close(() => {
         ended.resolve()
@@ -135,6 +149,12 @@ test('migration (alone)', async (t) => {
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Migration (alone) | ${duration}ms |\n`)
       updateMaxRAM()
+      global.gc()
+      t.pass(`memory usage without indexes: ${reportMem()}`)
+      fs.appendFileSync(
+        reportPath,
+        `| Memory usage without indexes | ${reportMem()} |\n`
+      )
       await sleep(2000) // wait for new log FS writes to finalize
       sbot.close(() => {
         ended.resolve()
@@ -170,6 +190,7 @@ test('initial indexing', async (t) => {
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Initial indexing | ${duration}ms |\n`)
       updateMaxRAM()
+      global.gc()
       sbot.close(() => {
         ended.resolve()
       })
@@ -200,6 +221,7 @@ test('initial indexing compat', async (t) => {
         `| Initial indexing compat | ${duration}ms |\n`
       )
       updateMaxRAM()
+      global.gc()
       sbot.close(() => {
         ended.resolve()
       })
@@ -234,6 +256,7 @@ test('Two indexes updating concurrently', async (t) => {
       `| Two indexes updating concurrently | ${duration}ms |\n`
     )
     updateMaxRAM()
+    global.gc()
     sbot.close(() => ended.resolve())
   })
 
@@ -318,9 +341,8 @@ for (const title in queries) {
 }
 
 test('maximum RAM used', (t) => {
-  const mb = (maxRAM / 1000 / 1000).toFixed(2)
-  t.pass(`RAM: ${mb} MB`)
-  fs.appendFileSync(reportPath, `| Maximum heap size | ${mb} MB |\n`)
+  t.pass(`maximum memory usage: ${reportMem()}`)
+  fs.appendFileSync(reportPath, `| Maximum memory usage | ${reportMem()} |\n`)
   t.end()
 })
 

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "test": "tape test/*.js | tap-spec",
     "format-code": "prettier --write \"*.js\" \"(test|compat|indexes|operators)/*.js\"",
     "format-code-staged": "pretty-quick --staged --pattern \"*.js\" --pattern \"(test|compat|indexes|operators)/*.js\"",
-    "benchmark": "node benchmark/index.js | tap-spec",
-    "benchmark-no-create": "node benchmark/index.js noCreate | tap-spec"
+    "benchmark": "node --expose-gc benchmark/index.js | tap-spec",
+    "benchmark-no-create": "node --expose-gc benchmark/index.js noCreate | tap-spec"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
`.rss` covers everything, while `.heapTotal` is just objects, arrays, strings, buffers, things like that. I believe we have a LOT of data put in the stack, because we heavily rely on small numbers and small strings.

I checked in `htop`, both desktop and mobile (yeah you can do `htop` in Termux on Android) and memory usage of Node.js on desktop and of Manyverse on Android (using the latest ssb-db2) float around half a gigabyte.