### PR TITLE
add benchmarks for all migrate situations

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -245,12 +245,14 @@ test('migrate continuation (+db2)', async (t) => {
 
   pull(
     fromEvent('ssb:db2:migrate:progress', sbot),
-    pull.filter((progress) => progress > 0.5),
+    pull.filter((progress) => progress > 0.9),
     pull.take(1),
     pull.drain(async () => {
+      sbot.db2migrate.stop()
       await sleep(4000) // wait for new log FS writes to finalize
       await new Promise((r) => sbot.close(() => r()))
       await sleep(500) // some silence
+      t.pass('migrated 90%, will reset sbot')
 
       sbot = SecretStack({ appKey: caps.shs })
         .use(require('../'))

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -79,7 +79,7 @@ function reportMem() {
   return `${rss} MB = ${heap} MB + etc`
 }
 
-test('migration (using ssb-db)', async (t) => {
+test('migrate (+db1)', async (t) => {
   rimraf.sync(db2Path)
   t.pass('delete db2 folder to start clean')
 
@@ -109,10 +109,7 @@ test('migration (using ssb-db)', async (t) => {
     pull.drain(async () => {
       const duration = Date.now() - start
       t.pass(`duration: ${duration}ms`)
-      fs.appendFileSync(
-        reportPath,
-        `| Migration (using ssb-db) | ${duration}ms |\n`
-      )
+      fs.appendFileSync(reportPath, `| Migrate (+db1) | ${duration}ms |\n`)
       updateMaxRAM()
       global.gc()
       await sleep(2000) // wait for new log FS writes to finalize
@@ -125,7 +122,7 @@ test('migration (using ssb-db)', async (t) => {
   await ended.promise
 })
 
-test('migration (alone)', async (t) => {
+test('migrate (alone)', async (t) => {
   rimraf.sync(db2Path)
   t.pass('delete db2 folder to start clean')
 
@@ -147,7 +144,7 @@ test('migration (alone)', async (t) => {
     pull.drain(async () => {
       const duration = Date.now() - start
       t.pass(`duration: ${duration}ms`)
-      fs.appendFileSync(reportPath, `| Migration (alone) | ${duration}ms |\n`)
+      fs.appendFileSync(reportPath, `| Migrate (alone) | ${duration}ms |\n`)
       updateMaxRAM()
       global.gc()
       t.pass(`memory usage without indexes: ${reportMem()}`)
@@ -159,6 +156,126 @@ test('migration (alone)', async (t) => {
       sbot.close(() => {
         ended.resolve()
       })
+    })
+  )
+
+  await ended.promise
+})
+
+test('migrate (+db1 +db2)', async (t) => {
+  rimraf.sync(db2Path)
+  t.pass('delete db2 folder to start clean')
+
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('ssb-db'))
+    .use(require('../'))
+    .call(null, { keys, path: dir })
+
+  await sleep(500) // some silence to make it easier to read the CPU profiler
+
+  const ended = DeferredPromise()
+  const start = Date.now()
+  sbot.db2migrate.start()
+
+  pull(
+    fromEvent('ssb:db2:migrate:progress', sbot),
+    pull.filter((progress) => progress === 1),
+    pull.take(1),
+    pull.drain(async () => {
+      const duration = Date.now() - start
+      t.pass(`duration: ${duration}ms`)
+      fs.appendFileSync(reportPath, `| Migrate (+db1 +db2) | ${duration}ms |\n`)
+      await sleep(4000) // wait for new log FS writes to finalize
+      sbot.close(() => {
+        ended.resolve()
+      })
+    })
+  )
+
+  await ended.promise
+})
+
+test('migrate (+db2)', async (t) => {
+  rimraf.sync(db2Path)
+  t.pass('delete db2 folder to start clean')
+
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .call(null, { keys, path: dir })
+
+  await sleep(500) // some silence to make it easier to read the CPU profiler
+
+  const ended = DeferredPromise()
+  const start = Date.now()
+  sbot.db2migrate.start()
+
+  pull(
+    fromEvent('ssb:db2:migrate:progress', sbot),
+    pull.filter((progress) => progress === 1),
+    pull.take(1),
+    pull.drain(async () => {
+      const duration = Date.now() - start
+      t.pass(`duration: ${duration}ms`)
+      fs.appendFileSync(reportPath, `| Migrate (+db2) | ${duration}ms |\n`)
+      await sleep(4000) // wait for new log FS writes to finalize
+      sbot.close(() => {
+        ended.resolve()
+      })
+    })
+  )
+
+  await ended.promise
+})
+
+test('migrate continuation (+db2)', async (t) => {
+  rimraf.sync(db2Path)
+  t.pass('delete db2 folder to start clean')
+
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  let sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .call(null, { keys, path: dir })
+
+  await sleep(500) // some silence to make it easier to read the CPU profiler
+
+  const ended = DeferredPromise()
+  sbot.db2migrate.start()
+
+  pull(
+    fromEvent('ssb:db2:migrate:progress', sbot),
+    pull.filter((progress) => progress > 0.5),
+    pull.take(1),
+    pull.drain(async () => {
+      await sleep(4000) // wait for new log FS writes to finalize
+      await new Promise((r) => sbot.close(() => r()))
+      await sleep(500) // some silence
+
+      sbot = SecretStack({ appKey: caps.shs })
+        .use(require('../'))
+        .call(null, { keys, path: dir })
+
+      const start = Date.now()
+      sbot.db2migrate.start()
+
+      pull(
+        fromEvent('ssb:db2:migrate:progress', sbot),
+        pull.filter((progress) => progress === 1),
+        pull.take(1),
+        pull.drain(async () => {
+          const duration = Date.now() - start
+          t.pass(`duration: ${duration}ms`)
+          fs.appendFileSync(
+            reportPath,
+            `| Migrate continuation (+db2) | ${duration}ms |\n`
+          )
+          await sleep(4000) // wait for new log FS writes to finalize
+          sbot.close(() => {
+            ended.resolve()
+          })
+        })
+      )
     })
   )
 

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -186,7 +186,7 @@ test('migrate (+db1 +db2)', async (t) => {
       const duration = Date.now() - start
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Migrate (+db1 +db2) | ${duration}ms |\n`)
-      await sleep(4000) // wait for new log FS writes to finalize
+      await new Promise((resolve) => sbot.db.onDrain(resolve))
       sbot.close(() => {
         ended.resolve()
       })
@@ -219,7 +219,7 @@ test('migrate (+db2)', async (t) => {
       const duration = Date.now() - start
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Migrate (+db2) | ${duration}ms |\n`)
-      await sleep(4000) // wait for new log FS writes to finalize
+      await new Promise((resolve) => sbot.db.onDrain(resolve))
       sbot.close(() => {
         ended.resolve()
       })
@@ -249,8 +249,8 @@ test('migrate continuation (+db2)', async (t) => {
     pull.take(1),
     pull.drain(async () => {
       sbot.db2migrate.stop()
-      await sleep(4000) // wait for new log FS writes to finalize
-      await new Promise((r) => sbot.close(() => r()))
+      await new Promise((resolve) => sbot.db.onDrain(resolve))
+      await new Promise((resolve) => sbot.close(resolve))
       await sleep(500) // some silence
       t.pass('migrated 90%, will reset sbot')
 
@@ -272,7 +272,7 @@ test('migrate continuation (+db2)', async (t) => {
             reportPath,
             `| Migrate continuation (+db2) | ${duration}ms |\n`
           )
-          await sleep(4000) // wait for new log FS writes to finalize
+          await new Promise((resolve) => sbot.db.onDrain(resolve))
           sbot.close(() => {
             ended.resolve()
           })

--- a/log.js
+++ b/log.js
@@ -49,6 +49,7 @@ module.exports = function (dir, config, privateIndex) {
   // and to decrypt the msg
   const originalStream = log.stream
   log.stream = function (opts) {
+    const shouldDecrypt = opts.decrypt === false ? false : true
     const tooHot = config.db2.maxCpu
       ? TooHot({ ceiling: config.db2.maxCpu, maxPause: 1000 })
       : () => false
@@ -61,12 +62,14 @@ module.exports = function (dir, config, privateIndex) {
         if (hot && !s.sink.paused) {
           s.sink.paused = true
           hot.then(() => {
-            originalWrite(privateIndex.decrypt(record, true))
+            if (shouldDecrypt) originalWrite(privateIndex.decrypt(record, true))
+            else originalWrite(record)
             s.sink.paused = false
             s.resume()
           })
         } else {
-          originalWrite(privateIndex.decrypt(record, true))
+          if (shouldDecrypt) originalWrite(privateIndex.decrypt(record, true))
+          else originalWrite(record)
         }
       }
       return originalPipe(o)


### PR DESCRIPTION
Adds new API:

- `sbot.db2migrate.stop` (needed for one new benchmark)

Adds new benchmark tests:

- Run migrate together with db1 and db2
- Run migrate and db2, but no db1
- Run migrate and db2, continuing from a 90%-completed previous migration, to test migrate's `findMigratedOffset` function

Optimizes migrate's `inefficientFindMigratedOffset`:

- This was doing a log.stream, but it never read the contents of the records, so this PR adds a `decrypt: false` opt that bypasses private.decrypt
  - Even though private.decrypt has some checks that skip the majority of unbox calls, this new optimization skips the unbox call also when the msg is intended for the author (i.e. canDecrypt)
  - This improves the "Migrate continuation (+db2)" benchmark run by -15%