### PR TITLE
before deleting index item, must flush batch

### DIFF
--- a/indexes/base.js
+++ b/indexes/base.js
@@ -73,8 +73,11 @@ module.exports = class BaseIndex extends Plugin {
   }
 
   removeFeedFromLatest(feedId) {
-    this.level.del(feedId, (err) => {
+    this.flush((err) => {
       if (err) throw err
+      this.level.del(feedId, (err2) => {
+        if (err2) throw err2
+      })
     })
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -185,7 +185,7 @@ test('validate needs to load', (t) => {
       db.publish(post, (err, msg) => {
         t.error(err, 'no err')
 
-        t.notEqual(msg.value.previous, null)
+        t.equal(msg.value.previous, null)
 
         db.onDrain(() => {
           sbot.close(() => {


### PR DESCRIPTION
The tests are wrong in one spot, see this comment: https://github.com/ssb-ngi-pointer/ssb-db2/pull/179#issuecomment-779356642

Also, besides the tests being wrong, also so was the implementation of delete. I don't have proof in the tests, but you can easily confirm this by yourself by putting some console.logs here and there: the `level.del` happens **1st** and **then** our batch system kicks in, **re-adding** the item that should be deleted.

This PR adds a commit that fixes the delete, to flush first. This will cause tests to fail. Then, I'll fix the test.