### PR TITLE
Benchmark disk

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -112,8 +112,6 @@ test('migrate (+db1)', async (t) => {
       const duration = Date.now() - start
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Migrate (+db1) | ${duration}ms |\n`)
-      updateMaxRAM()
-      global.gc()
       await sleep(2000) // wait for new log FS writes to finalize
       sbot.close(() => {
         ended.resolve()
@@ -147,13 +145,6 @@ test('migrate (alone)', async (t) => {
       const duration = Date.now() - start
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Migrate (alone) | ${duration}ms |\n`)
-      updateMaxRAM()
-      global.gc()
-      t.pass(`memory usage without indexes: ${reportMem()}`)
-      fs.appendFileSync(
-        reportPath,
-        `| Memory usage without indexes | ${reportMem()} |\n`
-      )
       await sleep(2000) // wait for new log FS writes to finalize
       sbot.close(() => {
         ended.resolve()
@@ -260,6 +251,10 @@ test('migrate continuation (+db2)', async (t) => {
         .use(require('../'))
         .call(null, { keys, path: dir })
 
+      global.gc()
+      await sleep(500)
+      updateMaxRAM() // will report later, just to make the report order pretty
+
       const start = Date.now()
       sbot.db2migrate.start()
 
@@ -284,6 +279,15 @@ test('migrate continuation (+db2)', async (t) => {
   )
 
   await ended.promise
+})
+
+test('Memory usage without indexes', (t) => {
+  t.pass(`memory usage without indexes: ${reportMem()}`)
+  fs.appendFileSync(
+    reportPath,
+    `| Memory usage without indexes | ${reportMem()} |\n`
+  )
+  t.end()
 })
 
 test('initial indexing', async (t) => {

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -11,6 +11,7 @@ const multicb = require('multicb')
 const pull = require('pull-stream')
 const fromEvent = require('pull-stream-util/from-event')
 const DeferredPromise = require('p-defer')
+const trammel = require('trammel')
 const sleep = require('util').promisify(setTimeout)
 const {
   and,
@@ -593,6 +594,14 @@ test('maximum RAM used', (t) => {
   t.pass(`maximum memory usage: ${reportMem()}`)
   fs.appendFileSync(reportPath, `| Maximum memory usage | ${reportMem()} |\n`)
   t.end()
+})
+
+test('Indexes folder size', (t) => {
+  trammel(indexesPath).then((size) => {
+    t.pass(`indexes folder size: ${size}`)
+    fs.appendFileSync(reportPath, `| Indexes folder size | ${size} |\n`)
+    t.end()
+  })
 })
 
 test('teardown', (t) => {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "ssb-friends": "4.4.3",
     "ssb-threads": "7.0.0-rc4",
     "tap-spec": "^5.0.0",
-    "tape": "^5.0.1"
+    "tape": "^5.0.1",
+    "trammel": "~4.0.0"
   },
   "scripts": {
     "test": "tape test/*.js | tap-spec",


### PR DESCRIPTION
- add benchmark for indexes folder size
- fix benchmark for memory usage without indexes 
  - It was measuring slightly at the wrong time, we want it to measure when db2 is running light (or none) workloads of migrate, and no indexes