### PR TITLE
add sbot.keys in compat

### DIFF
--- a/compat/db.js
+++ b/compat/db.js
@@ -12,6 +12,7 @@ exports.init = function (sbot, config) {
   sbot.publish = sbot.db.publish
   sbot.whoami = () => ({ id: sbot.id })
   sbot.ready = () => true
+  sbot.keys = config.keys
   sbot.createWriteStream = function createWriteStream(cb) {
     return pull(
       pull.asyncMap(sbot.db.add),

--- a/compat/index.js
+++ b/compat/index.js
@@ -1,9 +1,11 @@
 const db = require('./db')
 const ebt = require('./ebt')
 const hist = require('./history-stream')
+const logstream = require('./log-stream')
 
 exports.init = function (sbot, config) {
   db.init(sbot, config)
   ebt.init(sbot, config)
   hist.init(sbot, config)
+  logstream.init(sbot, config)
 }

--- a/test/compat.js
+++ b/test/compat.js
@@ -48,6 +48,11 @@ test('ready', (t) => {
   t.end()
 })
 
+test('keys', (t) => {
+  t.deepEqual(sbot.keys, keys)
+  t.end()
+})
+
 test('teardown sbot', (t) => {
   sbot.close(t.end)
 })


### PR DESCRIPTION
This was missing, it's needed in https://github.com/staltz/ssb-lan/blob/230daca3df3d00742d31938b398dcb9a212da031/src/index.ts#L95 and in db1 it's defined here https://github.com/ssbc/ssb-db/blob/8312ebe7df1b2b4e3282f75c73c753d8bc425dae/index.js#L122