### PR TITLE
fix flaky test "delete all"

### DIFF
--- a/db.js
+++ b/db.js
@@ -240,8 +240,7 @@ exports.init = function (sbot, config) {
           if (err) cb(err)
           else {
             delete state.feeds[feedId]
-            indexes.base.removeFeedFromLatest(feedId)
-            cb()
+            indexes.base.removeFeedFromLatest(feedId, cb)
           }
         })
       )

--- a/indexes/base.js
+++ b/indexes/base.js
@@ -73,12 +73,14 @@ module.exports = function makeBaseIndex(privateIndex) {
       this.level.get(feedId, { valueEncoding: this.valueEncoding }, cb)
     }
 
-    removeFeedFromLatest(feedId) {
+    removeFeedFromLatest(feedId, cb) {
       this.flush((err) => {
-        if (err) throw err
-        this.level.del(feedId, (err2) => {
-          if (err2) throw err2
-        })
+        if (err) cb(err)
+        else
+          this.level.del(feedId, (err2) => {
+            if (err2) cb(err2)
+            else cb()
+          })
       })
     }
   }

--- a/test/createLogStream.js
+++ b/test/createLogStream.js
@@ -94,7 +94,6 @@ test('createLogStream (live, !sync)', function (t) {
   pull(
     sbot.createLogStream({ live: true, sync: false }),
     pull.drain(function (m) {
-      console.log(m)
       if (m.sync) t.fail('there should be no {sync: true}')
       t.true(m.timestamp > ts)
       t.equal(m.value.content.type, 'food')


### PR DESCRIPTION
The "delete all" test was sometimes failing. It makes sense that `removeFeedFromLatest` needs a callback.