### PR TITLE
adjust maxCpu maxPause=180ms

### DIFF
--- a/log.js
+++ b/log.js
@@ -51,7 +51,7 @@ module.exports = function (dir, config, privateIndex) {
   log.stream = function (opts) {
     const shouldDecrypt = opts.decrypt === false ? false : true
     const tooHot = config.db2.maxCpu
-      ? TooHot({ ceiling: config.db2.maxCpu, wait: 90, maxPause: 300 })
+      ? TooHot({ ceiling: config.db2.maxCpu, wait: 90, maxPause: 180 })
       : () => false
     const s = originalStream(opts)
     const originalPipe = s.pipe.bind(s)


### PR DESCRIPTION
I ran some experiments, and found this sweet spot:

| initial sync duration | maxCpu    | UI responsiveness |
|------|-----------|-------------------|
| 305s | 86 (maxPause=300) | good              |
| 299s | 90 (maxPause=300) | good              |
| 288s | 92 (maxPause=300) | good              |
| **222s** | **92 (maxPause=180)** | **good**              |
| 158s | 92 (maxPause=90)  | a bit bad         |
| 281s | 95 (maxPause=300) | a bit bad         |
| 280s | 99 (maxPause=300) | bad               |
| 126s | Infinity          | bad   |