### PR TITLE
use pull-drain-gently in migrate

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -4,3 +4,11 @@ exports.BLOCK_SIZE = 64 * 1024
 exports.oldLogPath = (dir) => path.join(dir, 'flume', 'log.offset')
 exports.newLogPath = (dir) => path.join(dir, 'db2', 'log.bipf')
 exports.indexesPath = (dir) => path.join(dir, 'db2', 'indexes')
+exports.tooHotOpts = (config) =>
+  config.db2
+    ? {
+        ceiling: config.db2.maxCpu || Infinity,
+        wait: config.db2.maxCpuWait || 90,
+        maxPause: config.db2.maxCpuMaxPause || 300,
+      }
+    : { ceiling: Infinity, wait: 90, maxPause: 300 }

--- a/log.js
+++ b/log.js
@@ -1,16 +1,11 @@
 const OffsetLog = require('async-append-only-log')
 const bipf = require('bipf')
 const TooHot = require('too-hot')
-const { BLOCK_SIZE, newLogPath } = require('./defaults')
+const { BLOCK_SIZE, newLogPath, tooHotOpts } = require('./defaults')
 
 module.exports = function (dir, config, privateIndex) {
   config = config || {}
   config.db2 = config.db2 || {}
-  const tooHotOpts = {
-    ceiling: config.db2.maxCpu,
-    wait: config.db2.maxCpuWait || 90,
-    maxPause: config.db2.maxCpuMaxPause || 300,
-  }
 
   const log = OffsetLog(newLogPath(dir), {
     blockSize: BLOCK_SIZE,
@@ -55,7 +50,7 @@ module.exports = function (dir, config, privateIndex) {
   const originalStream = log.stream
   log.stream = function (opts) {
     const shouldDecrypt = opts.decrypt === false ? false : true
-    const tooHot = config.db2.maxCpu ? TooHot(tooHotOpts) : () => false
+    const tooHot = config.db2.maxCpu ? TooHot(tooHotOpts(config)) : () => false
     const s = originalStream(opts)
     const originalPipe = s.pipe.bind(s)
     s.pipe = function pipe(o) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "pretty-quick": "^3.1.0",
     "promisify-4loc": "1.0.0",
     "pull-cont": "^0.1.1",
+    "pull-drain-gently": "^1.1.0",
     "pull-level": "^2.0.4",
     "pull-stream": "^3.6.14",
     "push-stream": "^11.0.0",


### PR DESCRIPTION
I admit I made PR #185 before, and then closed it, but I'm rerunning experiments here on my phone, and this definitely gives users control over the UI. It will be useful to allow users to navigate the UI, discover what's going on, read progress reports, etc, as opposed to feeling like the app died (when in reality it is doing useful work as fast as it can).

It will have a sizable impact on total migrate duration but as I outlined in #193, I think it's some apps will benefit from doing it gradually.