### PR TITLE
update async-append-only-log to 3.0.5

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -57,8 +57,6 @@ function scanAndCount(pushstream, cb) {
       count += 1
     },
     end: function (err) {
-      if (this.ended) return
-      this.ended = err || true
       cb(null, count)
     },
   })

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:ssb-ngi-pointer/ssb-db2.git"
   },
   "dependencies": {
-    "async-append-only-log": "^3.0.4",
+    "async-append-only-log": "^3.0.5",
     "atomically-universal": "^0.1.1",
     "binary-search-bounds": "^2.0.4",
     "bipf": "~1.4.0",


### PR DESCRIPTION
The changes I made to asyncAOL's log.stream make one test (migrate) not pass anymore.