### PR TITLE
use array shape for secret-stack plugins

### DIFF
--- a/compat/index.js
+++ b/compat/index.js
@@ -1,11 +1,6 @@
-const db = require('./db')
-const ebt = require('./ebt')
-const hist = require('./history-stream')
-const logstream = require('./log-stream')
-
-exports.init = function (sbot, config) {
-  db.init(sbot, config)
-  ebt.init(sbot, config)
-  hist.init(sbot, config)
-  logstream.init(sbot, config)
-}
+module.exports = [
+  require('./db'),
+  require('./ebt'),
+  require('./history-stream'),
+  require('./log-stream'),
+]

--- a/index.js
+++ b/index.js
@@ -1,4 +1,1 @@
-const dbPlugin = require('./db')
-const migratePlugin = require('./migrate')
-
-module.exports = [dbPlugin, migratePlugin]
+module.exports = [require('./db'), require('./migrate')]


### PR DESCRIPTION
`compat/index.js` was calling only the `init()` of each child plugin, this was skipping all the `manifest` and `permissions` that they were declaring.