### PR TITLE
increase timeouts in several tests

### DIFF
--- a/test/about-self.js
+++ b/test/about-self.js
@@ -99,7 +99,8 @@ test('get live profile', (t) => {
 })
 
 test('should load about-self from disk', (t) => {
-  sbot.close(() => {
+  sbot.close((err) => {
+    t.error(err)
     t.pass('closed sbot')
     sbot = SecretStack({ appKey: caps.shs })
       .use(require('../'))
@@ -118,5 +119,7 @@ test('should load about-self from disk', (t) => {
 })
 
 test('teardown sbot', (t) => {
-  sbot.close(t.end)
+  setTimeout(() => {
+    sbot.close(() => t.end())
+  }, 500)
 })

--- a/test/compat.js
+++ b/test/compat.js
@@ -54,5 +54,7 @@ test('keys', (t) => {
 })
 
 test('teardown sbot', (t) => {
-  sbot.close(t.end)
+  setTimeout(() => {
+    sbot.close(() => t.end())
+  }, 500)
 })

--- a/test/createLogStream.js
+++ b/test/createLogStream.js
@@ -124,5 +124,7 @@ test.skip('createLogStream (gt)', (t) => {
 })
 
 test('teardown sbot', (t) => {
-  sbot.close(t.end)
+  setTimeout(() => {
+    sbot.close(() => t.end())
+  }, 500)
 })

--- a/test/ebt.js
+++ b/test/ebt.js
@@ -102,5 +102,7 @@ test('add', (t) => {
 })
 
 test('teardown sbot', (t) => {
-  sbot.close(t.end)
+  setTimeout(() => {
+    sbot.close(t.end)
+  }, 500)
 })

--- a/test/full-mentions.js
+++ b/test/full-mentions.js
@@ -106,5 +106,7 @@ test('getMessagesByMention live', { timeout: 5000 }, (t) => {
 })
 
 test('teardown sbot', (t) => {
-  sbot.close(t.end)
+  setTimeout(() => {
+    sbot.close(() => t.end())
+  }, 500)
 })

--- a/test/migration.js
+++ b/test/migration.js
@@ -163,8 +163,14 @@ test('migrate does not read decrypted from old log', (t) => {
       },
     })
 
-  // This should run after the sbot.publish (below) completes
-  setTimeout(() => {
+  let content = { type: 'post', text: 'super secret', recps: [keys.id] }
+  content = ssbKeys.box(
+    content,
+    content.recps.map((x) => x.substr(1))
+  )
+  sbot.publish(content, (err, posted) => {
+    t.error(err, 'publish suceeded')
+    t.equals(typeof posted.value.content, 'string', 'private msg posted')
     sbot.db.query(
       and(type('post'), isPrivate()),
       toCallback((err, msgs) => {
@@ -174,16 +180,6 @@ test('migrate does not read decrypted from old log', (t) => {
         sbot.close(t.end)
       })
     )
-  }, 500)
-
-  let content = { type: 'post', text: 'super secret', recps: [keys.id] }
-  content = ssbKeys.box(
-    content,
-    content.recps.map((x) => x.substr(1))
-  )
-  sbot.publish(content, (err, posted) => {
-    t.error(err, 'publish suceeded')
-    t.equals(typeof posted.value.content, 'string', 'private msg posted')
   })
 })
 

--- a/test/operators.js
+++ b/test/operators.js
@@ -108,7 +108,7 @@ test('dedicated author index', (t) => {
             .find((f) => f.startsWith('value_author_@') && f.endsWith('.index'))
           t.ok(dedicatedIndex, 'dedicated index exists')
           t.end()
-        }, 500)
+        }, 1000)
       })
     )
   })
@@ -565,5 +565,7 @@ test('live alone', (t) => {
 })
 
 test('teardown sbot', (t) => {
-  sbot.close(t.end)
+  setTimeout(() => {
+    sbot.close(() => t.end())
+  }, 500)
 })


### PR DESCRIPTION
One error I was seeing often was

```
Error: Closed
    at Request._openAndNotClosed (/home/staltz/oss/ssb-db2/node_modules/.pnpm/random-access-storage@1.4.1/node_modules/random-access-storage/index.js:180:38)
    at Request._run (/home/staltz/oss/ssb-db2/node_modules/.pnpm/random-access-storage@1.4.1/node_modules/random-access-storage/index.js:203:16)
    at drainQueue (/home/staltz/oss/ssb-db2/node_modules/.pnpm/random-access-storage@1.4.1/node_modules/random-access-storage/index.js:246:48)
    at Request._unqueue (/home/staltz/oss/ssb-db2/node_modules/.pnpm/random-access-storage@1.4.1/node_modules/random-access-storage/index.js:167:23)
    at Request.callback (/home/staltz/oss/ssb-db2/node_modules/.pnpm/random-access-storage@1.4.1/node_modules/random-access-storage/index.js:172:8)
    at onclose (/home/staltz/oss/ssb-db2/node_modules/.pnpm/random-access-file@2.1.4/node_modules/random-access-file/index.js:118:9)
    at FSReqWrap.args [as oncomplete] (fs.js:140:20)
```

which seems to be strictly just random-access-storage not having enough time to do the proper close. Maybe this is something we have to weave together with AAOL and sbot.close hook in `db.js` so that `sbot.close` waits for random-access-storage to finish. For now, we just want tests to pass.