### PR TITLE
recalculate ssb-validate state when migrate ends

### DIFF
--- a/migrate.js
+++ b/migrate.js
@@ -221,6 +221,7 @@ exports.init = function init(sbot, config) {
     started = true
     debug('started')
 
+    if (sbot.db) sbot.db.setStateFeedsReady('migrating')
     synchronized.set(false)
 
     const oldLog = getOldLog(sbot, config)
@@ -313,10 +314,20 @@ exports.init = function init(sbot, config) {
 
         if (config.db2.dangerouslyKillFlumeWhenMigrated) {
           rimraf(flumePath(config.path), (err) => {
-            if (!err) oldLogExists.set(false)
-            doneMigrating()
+            if (err) return console.error(err)
+            if (sbot.db) {
+              sbot.db.loadStateFeeds(() => {
+                sbot.db.setStateFeedsReady(true)
+                oldLogExists.set(false)
+                doneMigrating()
+              })
+            } else {
+              oldLogExists.set(false)
+              doneMigrating()
+            }
           })
         } else {
+          if (sbot.db) sbot.db.loadStateFeeds()
           doneMigrating()
           migrateLive()
         }

--- a/migrate.js
+++ b/migrate.js
@@ -327,7 +327,11 @@ exports.init = function init(sbot, config) {
             }
           })
         } else {
-          if (sbot.db) sbot.db.loadStateFeeds()
+          if (sbot.db) {
+            sbot.db.loadStateFeeds(() => {
+              sbot.db.setStateFeedsReady(true)
+            })
+          }
           doneMigrating()
           migrateLive()
         }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,21 @@
+/**
+ * Obv utility to run the `cb` once, as soon as the condition given by
+ * `filter` is true.
+ */
+function onceWhen(obv, filter, cb) {
+  if (!obv) return cb()
+  let answered = false
+  let remove
+  remove = obv((x) => {
+    if (!filter(x)) return
+    if (answered) {
+      if (remove) remove(), (remove = null)
+    } else {
+      answered = true
+      if (remove) remove(), (remove = null)
+      cb()
+    }
+  })
+}
+
+module.exports = { onceWhen }

--- a/utils.js
+++ b/utils.js
@@ -9,10 +9,16 @@ function onceWhen(obv, filter, cb) {
   remove = obv((x) => {
     if (!filter(x)) return
     if (answered) {
-      if (remove) remove(), (remove = null)
+      if (remove) {
+        remove()
+        remove = null
+      }
     } else {
       answered = true
-      if (remove) remove(), (remove = null)
+      if (remove) {
+        remove()
+        remove = null
+      }
       cb()
     }
   })


### PR DESCRIPTION
Tested on my manyverse and didn't get #207 symptoms anymore. 

Ideally, it would be good to have tests for this, but it's quite a lot of work to setup everything to reproduce it (would require migrating a fixture, then replicating with some peers which have more data on that fixture). Doable, but I'm on a deadline.

Some more comments inline