### PR TITLE
Add test for adding a bunch of messages

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -9,6 +9,8 @@ const caps = require('ssb-caps')
 const ssbKeys = require('ssb-keys')
 const multicb = require('multicb')
 const pull = require('pull-stream')
+const asyncFilter = require('pull-async-filter')
+const validate = require('ssb-validate')
 const fromEvent = require('pull-stream-util/from-event')
 const DeferredPromise = require('p-defer')
 const trammel = require('trammel')
@@ -29,10 +31,13 @@ const {
 } = require('../operators')
 
 const dir = '/tmp/ssb-db2-benchmark'
+const dirAdd = '/tmp/ssb-db2-benchmark-add'
 const oldLogPath = path.join(dir, 'flume', 'log.offset')
 const db2Path = path.join(dir, 'db2')
 const indexesPath = path.join(dir, 'db2', 'indexes')
 const reportPath = path.join(dir, 'benchmark.md')
+
+rimraf.sync(dirAdd)
 
 const skipCreate = process.argv[2] === 'noCreate'
 
@@ -87,6 +92,42 @@ test('setup', (t) => {
   t.end()
 })
 
+test('add a bunch of messages', async (t) => {
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .call(null, { keys, path: dirAdd })
+
+  let state = validate.initial()
+  for (var i = 0; i < 1000; ++i) {
+    state = validate.appendNew(state, null, keys, { type: 'tick', count: i }, Date.now())
+  }
+
+  const ended = DeferredPromise()
+  const start = Date.now()
+
+  pull(
+    pull.values(state.queue.map(x => x.value)),
+    asyncFilter(sbot.db.add),
+    pull.collect((err) => {
+      if (err) t.fail(err)
+
+      const duration = Date.now() - start
+      t.pass(`duration: ${duration}ms`)
+      fs.appendFileSync(
+        reportPath,
+        `| add 1000 elements | ${duration}ms |\n`
+      )
+
+      sbot.close(() => {
+        t.end()
+        ended.resolve()
+      })
+    })
+  )
+
+  await ended.promise
+})
+
 test('migrate (+db1)', async (t) => {
   rimraf.sync(db2Path)
   t.pass('delete db2 folder to start clean')
@@ -119,6 +160,7 @@ test('migrate (+db1)', async (t) => {
       fs.appendFileSync(reportPath, `| Migrate (+db1) | ${duration}ms |\n`)
       await sleep(2000) // wait for new log FS writes to finalize
       sbot.close(() => {
+        t.end()
         ended.resolve()
       })
     })
@@ -151,6 +193,7 @@ test('migrate (alone)', async (t) => {
       fs.appendFileSync(reportPath, `| Migrate (alone) | ${duration}ms |\n`)
       await sleep(2000) // wait for new log FS writes to finalize
       sbot.close(() => {
+        t.end()
         ended.resolve()
       })
     })
@@ -184,6 +227,7 @@ test('migrate (+db1 +db2)', async (t) => {
       fs.appendFileSync(reportPath, `| Migrate (+db1 +db2) | ${duration}ms |\n`)
       await new Promise((resolve) => sbot.db.onDrain(resolve))
       sbot.close(() => {
+        t.end()
         ended.resolve()
       })
     })
@@ -216,6 +260,7 @@ test('migrate (+db2)', async (t) => {
       fs.appendFileSync(reportPath, `| Migrate (+db2) | ${duration}ms |\n`)
       await new Promise((resolve) => sbot.db.onDrain(resolve))
       sbot.close(() => {
+        t.end()
         ended.resolve()
       })
     })
@@ -272,6 +317,7 @@ test('migrate continuation (+db2)', async (t) => {
           )
           await new Promise((resolve) => sbot.db.onDrain(resolve))
           sbot.close(() => {
+            t.end()
             ended.resolve()
           })
         })
@@ -317,6 +363,7 @@ test('initial indexing', async (t) => {
       updateMaxRAM()
       global.gc()
       sbot.close(() => {
+        t.end()
         ended.resolve()
       })
     })
@@ -357,6 +404,7 @@ test('initial indexing maxcpu 86', async (t) => {
       updateMaxRAM()
       global.gc()
       sbot.close(() => {
+        t.end()
         ended.resolve()
       })
     })
@@ -387,6 +435,7 @@ test('initial indexing compat', async (t) => {
       updateMaxRAM()
       global.gc()
       sbot.close(() => {
+        t.end()
         ended.resolve()
       })
     })
@@ -420,7 +469,10 @@ test('Two indexes updating concurrently', async (t) => {
     )
     updateMaxRAM()
     global.gc()
-    sbot.close(() => ended.resolve())
+    sbot.close(() => {
+      t.end()
+      ended.resolve()
+    })
   })
 
   await ended.promise

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -102,26 +102,26 @@ test('add a bunch of messages', async (t) => {
     state = validate.appendNew(state, null, keys, { type: 'tick', count: i }, Date.now())
   }
 
+  const messages = state.queue.map(x => x.value)
+
   const ended = DeferredPromise()
   const start = Date.now()
 
   pull(
-    pull.values(state.queue.map(x => x.value)),
+    pull.values(messages),
     asyncFilter(sbot.db.add),
     pull.collect((err) => {
+      const duration = Date.now() - start
+
       if (err) t.fail(err)
 
-      const duration = Date.now() - start
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(
         reportPath,
         `| add 1000 elements | ${duration}ms |\n`
       )
 
-      sbot.close(() => {
-        t.end()
-        ended.resolve()
-      })
+      sbot.close(() => ended.resolve())
     })
   )
 
@@ -159,10 +159,7 @@ test('migrate (+db1)', async (t) => {
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Migrate (+db1) | ${duration}ms |\n`)
       await sleep(2000) // wait for new log FS writes to finalize
-      sbot.close(() => {
-        t.end()
-        ended.resolve()
-      })
+      sbot.close(() => ended.resolve())
     })
   )
 
@@ -192,10 +189,7 @@ test('migrate (alone)', async (t) => {
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Migrate (alone) | ${duration}ms |\n`)
       await sleep(2000) // wait for new log FS writes to finalize
-      sbot.close(() => {
-        t.end()
-        ended.resolve()
-      })
+      sbot.close(() => ended.resolve())
     })
   )
 
@@ -226,10 +220,7 @@ test('migrate (+db1 +db2)', async (t) => {
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Migrate (+db1 +db2) | ${duration}ms |\n`)
       await new Promise((resolve) => sbot.db.onDrain(resolve))
-      sbot.close(() => {
-        t.end()
-        ended.resolve()
-      })
+      sbot.close(() => ended.resolve())
     })
   )
 
@@ -259,10 +250,7 @@ test('migrate (+db2)', async (t) => {
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| Migrate (+db2) | ${duration}ms |\n`)
       await new Promise((resolve) => sbot.db.onDrain(resolve))
-      sbot.close(() => {
-        t.end()
-        ended.resolve()
-      })
+      sbot.close(() => ended.resolve())
     })
   )
 
@@ -316,10 +304,7 @@ test('migrate continuation (+db2)', async (t) => {
             `| Migrate continuation (+db2) | ${duration}ms |\n`
           )
           await new Promise((resolve) => sbot.db.onDrain(resolve))
-          sbot.close(() => {
-            t.end()
-            ended.resolve()
-          })
+          sbot.close(() => ended.resolve())
         })
       )
     })
@@ -362,10 +347,7 @@ test('initial indexing', async (t) => {
       fs.appendFileSync(reportPath, `| Initial indexing | ${duration}ms |\n`)
       updateMaxRAM()
       global.gc()
-      sbot.close(() => {
-        t.end()
-        ended.resolve()
-      })
+      sbot.close(() => ended.resolve())
     })
   )
 
@@ -403,10 +385,7 @@ test('initial indexing maxcpu 86', async (t) => {
       )
       updateMaxRAM()
       global.gc()
-      sbot.close(() => {
-        t.end()
-        ended.resolve()
-      })
+      sbot.close(() => ended.resolve())
     })
   )
 
@@ -434,10 +413,7 @@ test('initial indexing compat', async (t) => {
       )
       updateMaxRAM()
       global.gc()
-      sbot.close(() => {
-        t.end()
-        ended.resolve()
-      })
+      sbot.close(() => ended.resolve())
     })
   })
 
@@ -469,10 +445,7 @@ test('Two indexes updating concurrently', async (t) => {
     )
     updateMaxRAM()
     global.gc()
-    sbot.close(() => {
-      t.end()
-      ended.resolve()
-    })
+    sbot.close(() => ended.resolve())
   })
 
   await ended.promise

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
     "promisify-4loc": "1.0.0",
+    "pull-async-filter": "^1.0.0",
     "pull-cont": "^0.1.1",
     "pull-drain-gently": "^1.1.0",
     "pull-level": "^2.0.4",


### PR DESCRIPTION
I noticed we didn't have a benchmark of simply adding a bunch of messages. This is useful for testing stuff like how fast can we add 1000 messages coming from EBT.