### PR TITLE
Auto encrypted publish when recps is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,8 @@ method is safe to use.
 ### publish(msg, cb)
 
 Convenience method for validating and adding a message to the database
-written by the feed running the secret-stack.
+written by the feed running the secret-stack. If message contains
+recps, the message will automatically be encrypted.
 
 ### add(msg, cb)
 

--- a/db.js
+++ b/db.js
@@ -219,10 +219,7 @@ exports.init = function (sbot, config) {
       (ready) => ready === true,
       () => {
         if (msg.recps) {
-          msg = ssbKeys.box(
-            msg,
-            msg.recps.map((x) => x.substr(1))
-          )
+          msg = ssbKeys.box(msg, msg.recps)
         }
 
         state.queue = []

--- a/db.js
+++ b/db.js
@@ -1,4 +1,5 @@
 const push = require('push-stream')
+const ssbKeys = require('ssb-keys')
 const hash = require('ssb-keys/util').hash
 const validate = require('ssb-validate')
 const Obv = require('obz')
@@ -217,8 +218,16 @@ exports.init = function (sbot, config) {
       stateFeedsReady,
       (ready) => ready === true,
       () => {
+        if (msg.recps) {
+          msg = ssbKeys.box(
+            msg,
+            msg.recps.map((x) => x.substr(1))
+          )
+        }
+
         state.queue = []
         state = validate.appendNew(state, null, config.keys, msg, Date.now())
+
         rawAdd(state.queue[0].value, true, (err, data) => {
           post.set(data)
           cb(err, data)

--- a/db.js
+++ b/db.js
@@ -218,9 +218,7 @@ exports.init = function (sbot, config) {
       stateFeedsReady,
       (ready) => ready === true,
       () => {
-        if (msg.recps) {
-          msg = ssbKeys.box(msg, msg.recps)
-        }
+        if (msg.recps) msg = ssbKeys.box(msg, msg.recps)
 
         state.queue = []
         state = validate.appendNew(state, null, config.keys, msg, Date.now())

--- a/test/base-index.js
+++ b/test/base-index.js
@@ -89,7 +89,7 @@ test('get all latest', (t) => {
         t.equal(postMsg.value.sequence, status.sequence)
         t.equal(postMsg.value.timestamp, status.timestamp)
 
-        t.end()
+        sbot.close(t.end)
       })
     })
   })

--- a/test/base-index.js
+++ b/test/base-index.js
@@ -94,20 +94,3 @@ test('get all latest', (t) => {
     })
   })
 })
-
-test('encrypted', (t) => {
-  let content = { type: 'post', text: 'super secret', recps: [keys.id] }
-  content = ssbKeys.box(
-    content,
-    content.recps.map((x) => x.substr(1))
-  )
-
-  db.publish(content, (err, privateMsg) => {
-    t.error(err, 'no err')
-
-    db.get(privateMsg.key, (err, msg) => {
-      t.equal(msg.content.text, 'super secret')
-      sbot.close(t.end)
-    })
-  })
-})

--- a/test/private.js
+++ b/test/private.js
@@ -1,0 +1,52 @@
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+
+const dir = '/tmp/ssb-db2-private'
+
+rimraf.sync(dir)
+mkdirp.sync(dir)
+
+const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+
+const sbot = SecretStack({ appKey: caps.shs }).use(require('../')).call(null, {
+  keys,
+  path: dir,
+})
+const db = sbot.db
+
+test('publish encrypted message', (t) => {
+  let content = { type: 'post', text: 'super secret', recps: [keys.id] }
+  content = ssbKeys.box(
+    content,
+    content.recps.map((x) => x.substr(1))
+  )
+
+  db.publish(content, (err, privateMsg) => {
+    t.error(err, 'no err')
+
+    t.equal(typeof privateMsg.value.content, 'string')
+    db.get(privateMsg.key, (err, msg) => {
+      t.equal(msg.content.text, 'super secret')
+      t.end()
+    })
+  })
+})
+
+test('publish: auto encrypt message with recps', (t) => {
+  let content = { type: 'post', text: 'super secret', recps: [keys.id] }
+
+  db.publish(content, (err, privateMsg) => {
+    t.error(err, 'no err')
+
+    t.equal(typeof privateMsg.value.content, 'string')
+    db.get(privateMsg.key, (err, msg) => {
+      t.equal(msg.content.text, 'super secret')
+      sbot.close(t.end)
+    })
+  })
+})


### PR DESCRIPTION
To fix #211. Current behaviour can be a bit of a gotcha when coming from db1. First commit is just a failing test.