### PR TITLE
Replace atomically-universal with atomic-file-rw

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "async-append-only-log": "^3.0.8",
-    "atomically-universal": "^0.1.1",
+    "atomic-file-rw": "^0.1.0",
     "binary-search-bounds": "^2.0.4",
     "bipf": "~1.5.0",
     "debug": "~4.3.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "async-append-only-log": "^3.0.8",
-    "atomic-file-rw": "^0.1.0",
+    "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
     "bipf": "~1.5.0",
     "debug": "~4.3.1",
@@ -17,7 +17,7 @@
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "hoox": "0.0.1",
-    "jitdb": "^3.0.3",
+    "jitdb": "^3.1.0",
     "level": "^6.0.1",
     "level-codec": "^9.0.2",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
Similar to the [PR](https://github.com/ssb-ngi-pointer/jitdb/pull/153) in jitdb. This is just a replace with another library. Also depends on this [PR](https://github.com/ssb-ngi-pointer/atomic-file-rw/pull/2) in atomic-file-rw hence the draft status.