### PR TITLE
log createWriteStream errors instead of throwing

### DIFF
--- a/compat/db.js
+++ b/compat/db.js
@@ -20,7 +20,7 @@ exports.init = function (sbot, config) {
         () => {},
         cb ||
           ((err) => {
-            if (err) throw err
+            console.error(`ssb-db2 createWriteStream got an error: ${err}`)
           })
       )
     )


### PR DESCRIPTION
## Context

We were debugging https://github.com/ssb-ngi-pointer/go-ssb-room/issues/190 and figured that if `pull.drain` receives an ending-error and doesn't have the `done` callback in `pull.drain(cb, done)`, then it throws the error. `throw err` is dangerously in that it may crash the app.

## Problem

ssb-db2's compat layer implements `createWriteStream`. While the only known usage of `createWriteStream` is ssb-replicate [which provides a `cb`](https://github.com/ssbc/ssb-replicate/blob/7567b077ade9350e287ae8d3a08a84ae84d8498b/legacy.js#L271) and thus should not trigger the `throw err` in `ssb-db2/compat/db`, it is still safer to handle this error in a non-crashing way, in case someone else uses `createWriteStream` without passing a callback.

## Solution

Avoid `throw err`, use `console.error` instead.