### PR TITLE
Call post on add functions like publish does

### DIFF
--- a/db.js
+++ b/db.js
@@ -159,7 +159,10 @@ exports.init = function (sbot, config) {
           state = validate.append(state, hmac_key, msg)
           if (state.error) return cb(state.error)
           const kv = state.queue[state.queue.length - 1]
-          log.add(kv.key, kv.value, cb)
+          log.add(kv.key, kv.value, (err, data) => {
+            post.set(data)
+            cb(err, data)
+          })
         } catch (ex) {
           return cb(ex)
         }
@@ -180,7 +183,11 @@ exports.init = function (sbot, config) {
       const kv = oooState.queue[oooState.queue.length - 1]
       get(kv.key, (err, data) => {
         if (data) cb(null, data)
-        else log.add(kv.key, kv.value, cb)
+        else
+          log.add(kv.key, kv.value, (err, data) => {
+            post.set(data)
+            cb(err, data)
+          })
       })
     } catch (ex) {
       return cb(ex)
@@ -201,7 +208,10 @@ exports.init = function (sbot, config) {
       if (strictOrderState.error) return cb(strictOrderState.error)
 
       const kv = strictOrderState.queue[strictOrderState.queue.length - 1]
-      log.add(kv.key, kv.value, cb)
+      log.add(kv.key, kv.value, (err, data) => {
+        post.set(data)
+        cb(err, data)
+      })
     } catch (ex) {
       return cb(ex)
     }
@@ -412,9 +422,9 @@ exports.init = function (sbot, config) {
     addOOOStrictOrder,
     getStatus: () => status.obv,
     operators,
+    post,
 
     // needed primarily internally by other plugins in this project:
-    post,
     getLatest: indexes.base.getLatest.bind(indexes.base),
     getAllLatest: indexes.base.getAllLatest.bind(indexes.base),
     getLog: () => log,

--- a/test/ebt.js
+++ b/test/ebt.js
@@ -69,6 +69,17 @@ test('Encrypted', (t) => {
     content.recps.map((x) => x.substr(1))
   )
 
+  let i = 0
+
+  var remove = sbot.db.post((msg) => {
+    if (i++ === 0)
+      t.equal(msg.value.sequence, 3, 'we get existing')
+    else {
+      t.equal(msg.value.sequence, 4, 'post is called on publish')
+      remove()
+    }
+  })
+
   db.publish(content, (err) => {
     t.error(err, 'no err')
 
@@ -91,6 +102,17 @@ test('add', (t) => {
     { type: 'post', text: 'testing sbot.add' },
     Date.now()
   )
+
+  let i = 0
+
+  var remove = sbot.db.post((msg) => {
+    if (i++ === 0)
+      t.equal(msg.value.author, keys.id, 'we get existing')
+    else {
+      t.equal(msg.value.author, keys2.id, 'post is called on add')
+      remove()
+    }
+  })
 
   sbot.add(state.queue[0].value, (err, added) => {
     t.error(err)


### PR DESCRIPTION
While testing unbermuda I noticed that something was up with EBT.

EBT on startup gets the [latest state](https://github.com/ssbc/ssb-ebt/blob/master/index.js#L81) and then maintains the state using [post](https://github.com/ssbc/ssb-ebt/blob/master/index.js#L87). It even uses this (internally)[https://github.com/ssbc/ssb-ebt/blob/master/index.js#L74] to manage state. The problem would manifest itself in EBT when having multiple EBT connections, then you would receive too many messages because the clock is not properly kept in sync. The problem could also be triggered by something other than EBT writing messages (which is how I found this problem).

DB1 called post on [both](https://github.com/ssbc/ssb-db/blob/b2256fd7e3e6e3804ca5f388b3fc351312250d05/minimal.js#L111) `add` and `publish`. 

I have tested this during an initial sync kind of scenario and the overhead does not seem to be very much. I was fearing that.