### PR TITLE
Box2 dm

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -33,12 +33,14 @@ const {
 
 const dir = '/tmp/ssb-db2-benchmark'
 const dirAdd = '/tmp/ssb-db2-benchmark-add'
+const dirPrivate = '/tmp/ssb-db2-benchmark-private'
 const oldLogPath = path.join(dir, 'flume', 'log.offset')
 const db2Path = path.join(dir, 'db2')
 const indexesPath = path.join(dir, 'db2', 'indexes')
 const reportPath = path.join(dir, 'benchmark.md')
 
 rimraf.sync(dirAdd)
+rimraf.sync(dirPrivate)
 
 const skipCreate = process.argv[2] === 'noCreate'
 
@@ -126,6 +128,100 @@ test('add a bunch of messages', async (t) => {
       fs.appendFileSync(reportPath, `| add 1000 elements | ${duration}ms |\n`)
 
       sbot.close(() => ended.resolve())
+    })
+  )
+
+  await ended.promise
+})
+
+test('private', async (t) => {
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .call(null, { keys, path: dirPrivate })
+
+  let contents = []
+  for (var i = 0; i < 1000; ++i)
+    contents.push({ type: 'tick', count: i, recps: [sbot.id] })
+
+  const ended = DeferredPromise()
+  const start = Date.now()
+
+  pull(
+    pull.values(contents),
+    pull.asyncMap(sbot.db.publish),
+    pull.collect((err, msgs) => {
+      const duration = Date.now() - start
+
+      if (err) t.fail(err)
+
+      t.pass(`duration: ${duration}ms`)
+      fs.appendFileSync(reportPath, `| add 1000 private box1 elements | ${duration}ms |\n`)
+
+      const startQuery = Date.now()
+
+      sbot.db.query(
+        where(author(sbot.id)),
+        toCallback((err, results) => {
+          const durationQuery = Date.now() - startQuery
+          t.pass(`unbox duration: ${durationQuery}ms`)
+          fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements | ${duration}ms |\n`)
+
+          sbot.close(() => ended.resolve())
+        })
+      )      
+    })
+  )
+
+  await ended.promise
+})
+
+test('private box2', async (t) => {
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .call(null, {
+      keys,
+      path: dirPrivate,
+      db2: {
+        alwaysbox2: true
+      }
+    })
+
+  const testkey = Buffer.from(
+    '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
+    'hex'
+  )
+  sbot.db.addBox2DMKey(testkey)
+
+  let contents = []
+  for (var i = 0; i < 1000; ++i)
+    contents.push({ type: 'tick', count: i, recps: [sbot.id] })
+
+  const ended = DeferredPromise()
+  const start = Date.now()
+
+  pull(
+    pull.values(contents),
+    pull.asyncMap(sbot.db.publish),
+    pull.collect((err, msgs) => {
+      const duration = Date.now() - start
+
+      if (err) t.fail(err)
+
+      t.pass(`box duration: ${duration}ms`)
+      fs.appendFileSync(reportPath, `| add 1000 private box2 elements | ${duration}ms |\n`)
+
+      const startQuery = Date.now()
+
+      sbot.db.query(
+        where(author(sbot.id)),
+        toCallback((err, results) => {
+          const durationQuery = Date.now() - startQuery
+          t.pass(`unbox duration: ${durationQuery}ms`)
+          fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements | ${duration}ms |\n`)
+
+          sbot.close(() => ended.resolve())
+        })
+      )
     })
   )
 

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -157,18 +157,31 @@ test('private', async (t) => {
       t.pass(`duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| add 1000 private box1 elements | ${duration}ms |\n`)
 
-      const startQuery = Date.now()
+      sbot.db.onDrain('base', () => {
+        let startQuery = Date.now()
 
-      sbot.db.query(
-        where(author(sbot.id)),
-        toCallback((err, results) => {
-          const durationQuery = Date.now() - startQuery
-          t.pass(`unbox duration: ${durationQuery}ms`)
-          fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements | ${duration}ms |\n`)
+        sbot.db.query(
+          where(author(sbot.id)),
+          toCallback((err, results) => {
+            const durationQuery = Date.now() - startQuery
+            t.pass(`unbox first run duration: ${durationQuery}ms`)
+            fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements first run | ${duration}ms |\n`)
 
-          sbot.close(() => ended.resolve())
-        })
-      )      
+            startQuery = Date.now()
+
+            sbot.db.query(
+              where(author(sbot.id)),
+              toCallback((err, results) => {
+                const durationQuery2 = Date.now() - startQuery
+                t.pass(`unbox second run duration: ${durationQuery2}ms`)
+                fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements second run | ${duration}ms |\n`)
+
+                sbot.close(() => ended.resolve())
+              })
+            )
+          })
+        )
+      })
     })
   )
 
@@ -210,18 +223,31 @@ test('private box2', async (t) => {
       t.pass(`box duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| add 1000 private box2 elements | ${duration}ms |\n`)
 
-      const startQuery = Date.now()
+      sbot.db.onDrain('base', () => {
+        let startQuery = Date.now()
 
-      sbot.db.query(
-        where(author(sbot.id)),
-        toCallback((err, results) => {
-          const durationQuery = Date.now() - startQuery
-          t.pass(`unbox duration: ${durationQuery}ms`)
-          fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements | ${duration}ms |\n`)
+        sbot.db.query(
+          where(author(sbot.id)),
+          toCallback((err, results) => {
+            const durationQuery = Date.now() - startQuery
+            t.pass(`unbox duration first run: ${durationQuery}ms`)
+            fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements first run | ${duration}ms |\n`)
+            
+            startQuery = Date.now()
 
-          sbot.close(() => ended.resolve())
-        })
-      )
+            sbot.db.query(
+              where(author(sbot.id)),
+              toCallback((err, results) => {
+                const durationQuery2 = Date.now() - startQuery
+                t.pass(`unbox duration second run: ${durationQuery2}ms`)
+                fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements first run | ${duration}ms |\n`)
+
+                sbot.close(() => ended.resolve())
+              })
+            )
+          })
+        )
+      })
     })
   )
 

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -135,14 +135,32 @@ test('add a bunch of messages', async (t) => {
   await ended.promise
 })
 
+const randos = [
+  ssbKeys.generate().id,
+  ssbKeys.generate().id,
+  ssbKeys.generate().id,
+  ssbKeys.generate().id,
+  ssbKeys.generate().id
+]
+
+function shuffle(a) {
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
 test('private', async (t) => {
   const sbot = SecretStack({ appKey: caps.shs })
     .use(require('../'))
     .call(null, { keys, path: dirPrivate })
 
+  const recps = [...randos, keys.id]
+
   let contents = []
   for (var i = 0; i < 1000; ++i)
-    contents.push({ type: 'tick', count: i, recps: [sbot.id] })
+    contents.push({ type: 'tick', count: i, recps: shuffle(recps) })
 
   const ended = DeferredPromise()
   const start = Date.now()
@@ -200,6 +218,8 @@ test('private box2', async (t) => {
       }
     })
 
+  const recps = [...randos, keys2.id]
+
   const testkey = Buffer.from(
     '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
     'hex'
@@ -208,7 +228,7 @@ test('private box2', async (t) => {
 
   let contents = []
   for (var i = 0; i < 1000; ++i)
-    contents.push({ type: 'tick', count: i, recps: [sbot.id] })
+    contents.push({ type: 'tick', count: i, recps: shuffle(recps) })
 
   const ended = DeferredPromise()
   const start = Date.now()
@@ -233,7 +253,7 @@ test('private box2', async (t) => {
             const durationQuery = Date.now() - startQuery
             t.pass(`unbox duration first run: ${durationQuery}ms`)
             fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements first run | ${duration}ms |\n`)
-            
+
             startQuery = Date.now()
 
             sbot.db.query(

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -89,9 +89,10 @@ function reportMem() {
   return `${rss} MB = ${heap} MB + etc`
 }
 
-let keys
+let keys, keys2
 test('setup', (t) => {
   keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  keys2 = ssbKeys.loadOrCreateSync(path.join(dirPrivate, 'secret'))
   t.end()
 })
 
@@ -154,7 +155,7 @@ test('private', async (t) => {
 
       if (err) t.fail(err)
 
-      t.pass(`duration: ${duration}ms`)
+      t.pass(`box duration: ${duration}ms`)
       fs.appendFileSync(reportPath, `| add 1000 private box1 elements | ${duration}ms |\n`)
 
       sbot.db.onDrain('base', () => {
@@ -192,7 +193,7 @@ test('private box2', async (t) => {
   const sbot = SecretStack({ appKey: caps.shs })
     .use(require('../'))
     .call(null, {
-      keys,
+      keys: keys2,
       path: dirPrivate,
       db2: {
         alwaysbox2: true

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -184,7 +184,7 @@ test('private', async (t) => {
           toCallback((err, results) => {
             const durationQuery = Date.now() - startQuery
             t.pass(`unbox first run duration: ${durationQuery}ms`)
-            fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements first run | ${duration}ms |\n`)
+            fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements first run | ${durationQuery}ms |\n`)
 
             startQuery = Date.now()
 
@@ -193,7 +193,7 @@ test('private', async (t) => {
               toCallback((err, results) => {
                 const durationQuery2 = Date.now() - startQuery
                 t.pass(`unbox second run duration: ${durationQuery2}ms`)
-                fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements second run | ${duration}ms |\n`)
+                fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements second run | ${durationQuery2}ms |\n`)
 
                 sbot.close(() => ended.resolve())
               })
@@ -252,7 +252,7 @@ test('private box2', async (t) => {
           toCallback((err, results) => {
             const durationQuery = Date.now() - startQuery
             t.pass(`unbox duration first run: ${durationQuery}ms`)
-            fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements first run | ${duration}ms |\n`)
+            fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements first run | ${durationQuery}ms |\n`)
 
             startQuery = Date.now()
 
@@ -261,7 +261,7 @@ test('private box2', async (t) => {
               toCallback((err, results) => {
                 const durationQuery2 = Date.now() - startQuery
                 t.pass(`unbox duration second run: ${durationQuery2}ms`)
-                fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements first run | ${duration}ms |\n`)
+                fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements first run | ${durationQuery2}ms |\n`)
 
                 sbot.close(() => ended.resolve())
               })

--- a/db.js
+++ b/db.js
@@ -9,6 +9,7 @@ const JITDb = require('jitdb')
 const { isFeed, isCloakedMsg: isGroup } = require('ssb-ref')
 const Debug = require('debug')
 
+const keystore = require('./keystore')
 const { indexesPath } = require('./defaults')
 const { onceWhen } = require('./utils')
 const Log = require('./log')
@@ -218,7 +219,6 @@ exports.init = function (sbot, config) {
     }
   }
 
-  // FIXME: keystore
   // FIXME: state
   function box2(content, previous) {
     if (content.recps.length > 16)
@@ -235,8 +235,8 @@ exports.init = function (sbot, config) {
       throw new Error('private-group spec only allows feedId in the first slot')
 
     const recipientKeys = content.recps.reduce((acc, recp) => {
-      if (recp === state.keys.id) return [...acc, keystore.ownKeys(recp)[0]]
-      else return [...acc, keystore.author.sharedDMKey(recp)]
+      if (recp === state.keys.id) return [...acc, keystore.ownKey]
+      else return [...acc, keystore.sharedDMKey(recp)]
     }, [])
 
     const plaintext = Buffer.from(JSON.stringify(content), 'utf8')
@@ -250,6 +250,7 @@ exports.init = function (sbot, config) {
       msgKey,
       recipientKeys
     )
+
     return envelope.toString('base64') + '.box2'
   }
 

--- a/db.js
+++ b/db.js
@@ -60,7 +60,8 @@ exports.init = function (sbot, config) {
   config.db2 = config.db2 || {}
   const indexes = {}
   const dir = config.path
-  const privateIndex = PrivateIndex(dir, config)
+  const keystore = KeyStore(config)
+  const privateIndex = PrivateIndex(dir, config, keystore)
   const log = Log(dir, config, privateIndex)
   const jitdb = JITDb(log, indexesPath(dir))
   const status = Status(log, jitdb)
@@ -69,7 +70,6 @@ exports.init = function (sbot, config) {
   const hmac_key = null
   const stateFeedsReady = Obv().set(false)
   let state = validate.initial()
-  const keystore = KeyStore(config)
 
   sbot.close.hook(function (fn, args) {
     close(() => {
@@ -239,7 +239,7 @@ exports.init = function (sbot, config) {
       throw new Error('private-group spec only allows feedId in the first slot')
 
     const recipientKeys = content.recps.reduce((acc, recp) => {
-      if (recp === config.keys.id) return [...acc, keystore.ownKey]
+      if (recp === config.keys.id) return [...acc, ...keystore.ownDMKeys()]
       else return [...acc, keystore.sharedDMKey(recp)]
     }, [])
 
@@ -469,6 +469,7 @@ exports.init = function (sbot, config) {
     getStatus: () => status.obv,
     operators,
     post,
+    addBox2DMKey: keystore.addBox2DMKey,
 
     // needed primarily internally by other plugins in this project:
     getLatest: indexes.base.getLatest.bind(indexes.base),

--- a/db.js
+++ b/db.js
@@ -9,6 +9,7 @@ const JITDb = require('jitdb')
 const { isFeed, isCloakedMsg: isGroup } = require('ssb-ref')
 const Debug = require('debug')
 
+const { box } = require('envelope-js')
 const SecretKey = require('ssb-tribes/lib/secret-key')
 const { MsgId } = require('ssb-tribes/lib/cipherlinks')
 const KeyStore = require('./keystore')
@@ -59,7 +60,7 @@ exports.init = function (sbot, config) {
   config.db2 = config.db2 || {}
   const indexes = {}
   const dir = config.path
-  const privateIndex = PrivateIndex(dir, config.keys)
+  const privateIndex = PrivateIndex(dir, config)
   const log = Log(dir, config, privateIndex)
   const jitdb = JITDb(log, indexesPath(dir))
   const status = Status(log, jitdb)
@@ -68,7 +69,7 @@ exports.init = function (sbot, config) {
   const hmac_key = null
   const stateFeedsReady = Obv().set(false)
   let state = validate.initial()
-  const keystore = KeyStore(config.keys)
+  const keystore = KeyStore(config)
 
   sbot.close.hook(function (fn, args) {
     close(() => {

--- a/db.js
+++ b/db.js
@@ -6,6 +6,7 @@ const promisify = require('promisify-4loc')
 const jitdbOperators = require('jitdb/operators')
 const operators = require('./operators')
 const JITDb = require('jitdb')
+const { isFeed, isCloakedMsg: isGroup } = require('ssb-ref')
 const Debug = require('debug')
 
 const { indexesPath } = require('./defaults')
@@ -217,6 +218,41 @@ exports.init = function (sbot, config) {
     }
   }
 
+  // FIXME: keystore
+  // FIXME: state
+  function box2(content, previous) {
+    if (content.recps.length > 16)
+      throw new Error(
+        `private-group spec allows maximum 16 slots, but you've tried to use ${content.recps.length}`
+      )
+
+    if (!isGroup(content.recps[0]) && !isFeed(content.recps[0]))
+      throw new Error(
+        'private-group spec only feedId or groupId in the first slot'
+      )
+
+    if (content.recps.length > 1 && !content.recps.slice(1).every(isFeed))
+      throw new Error('private-group spec only allows feedId in the first slot')
+
+    const recipientKeys = content.recps.reduce((acc, recp) => {
+      if (recp === state.keys.id) return [...acc, keystore.ownKeys(recp)[0]]
+      else return [...acc, keystore.author.sharedDMKey(recp)]
+    }, [])
+
+    const plaintext = Buffer.from(JSON.stringify(content), 'utf8')
+    const msgKey = new SecretKey().toBuffer()
+    const previousMessageId = new MsgId(previous).toTFK()
+
+    const envelope = box(
+      plaintext,
+      state.feedId,
+      previousMessageId,
+      msgKey,
+      recipientKeys
+    )
+    return envelope.toString('base64') + '.box2'
+  }
+
   function publish(msg, cb) {
     const guard = guardAgainstDuplicateLogs('publish()')
     if (guard) return cb(guard)
@@ -225,6 +261,9 @@ exports.init = function (sbot, config) {
       stateFeedsReady,
       (ready) => ready === true,
       () => {
+        // FIXME: some kind of check if we can use box2 or not
+        // probably related to if the recipient non-classic (a meta
+        // feed or fusion identity for now)
         if (msg.recps) msg = ssbKeys.box(msg, msg.recps)
 
         state.queue = []

--- a/db.js
+++ b/db.js
@@ -230,13 +230,8 @@ exports.init = function (sbot, config) {
         `private-group spec allows maximum 16 slots, but you've tried to use ${content.recps.length}`
       )
 
-    if (!isGroup(content.recps[0]) && !isFeed(content.recps[0]))
-      throw new Error(
-        'private-group spec only feedId or groupId in the first slot'
-      )
-
-    if (content.recps.length > 1 && !content.recps.slice(1).every(isFeed))
-      throw new Error('private-group spec only allows feedId in the first slot')
+    if (!content.recps.every(isFeed))
+      throw new Error('only feeds are supported as recipients') // for now
 
     const recipientKeys = content.recps.reduce((acc, recp) => {
       if (recp === config.keys.id) return [...acc, ...keystore.ownDMKeys()]

--- a/db.js
+++ b/db.js
@@ -265,10 +265,12 @@ exports.init = function (sbot, config) {
       stateFeedsReady,
       (ready) => ready === true,
       () => {
-        // FIXME: some kind of check if we can use box2 or not
-        // probably related to if the recipient non-classic (a meta
-        // feed or fusion identity for now)
-        if (msg.recps) msg = ssbKeys.box(msg, msg.recps)
+        if (msg.recps) {
+          if (msg.recps.every(keystore.supportsBox2)) {
+            const feedState = state.feeds[config.keys.id]
+            msg = box2(msg, feedState ? feedState.id : null)
+          } else msg = ssbKeys.box(msg, msg.recps)
+        }
 
         state.queue = []
         state = validate.appendNew(state, null, config.keys, msg, Date.now())

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -11,17 +11,14 @@ const Debug = require('debug')
 
 const { FeedId, MsgId } = require('ssb-tribes/lib/cipherlinks')
 const { unboxKey, unboxBody } = require('envelope-js')
-const KeyStore = require('../keystore')
 
 const { indexesPath } = require('../defaults')
 
-module.exports = function (dir, config) {
+module.exports = function (dir, config, keystore) {
   const latestOffset = Obv()
   const stateLoaded = DeferredPromise()
   let encrypted = []
   let canDecrypt = []
-
-  let keystore = KeyStore(config)
 
   const debug = Debug('ssb:db2:private')
 
@@ -135,7 +132,7 @@ module.exports = function (dir, config) {
 
     const trial_dm_keys = [
       keystore.sharedDMKey(author),
-      keystore.ownKey,
+      ...keystore.ownDMKeys()
     ]
 
     read_key = unboxKey(envelope, feed_id, prev_msg_id, trial_dm_keys, {

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -15,13 +15,13 @@ const KeyStore = require('../keystore')
 
 const { indexesPath } = require('../defaults')
 
-module.exports = function (dir, keys) {
+module.exports = function (dir, config) {
   const latestOffset = Obv()
   const stateLoaded = DeferredPromise()
   let encrypted = []
   let canDecrypt = []
 
-  let keystore = KeyStore(keys)
+  let keystore = KeyStore(config)
 
   const debug = Debug('ssb:db2:private')
 
@@ -134,8 +134,8 @@ module.exports = function (dir, keys) {
     const prev_msg_id = new MsgId(previous).toTFK()
 
     const trial_dm_keys = [
-      sharedDMKey(author),
-      ownKey,
+      keystore.sharedDMKey(author),
+      keystore.ownKey,
     ]
 
     read_key = unboxKey(envelope, feed_id, prev_msg_id, trial_dm_keys, {
@@ -153,7 +153,7 @@ module.exports = function (dir, keys) {
 
   function tryDecryptContent(ciphertext, recBuffer, pValue) {
     let content = ''
-    if (ciphertext.endsWith('.box')) content = decryptBox1(ciphertext, keys)
+    if (ciphertext.endsWith('.box')) content = decryptBox1(ciphertext, config.keys)
     else if (ciphertext.endsWith('.box2')) {
       const pAuthor = bipf.seekKey(recBuffer, pValue, bAuthor)
       if (pAuthor >= 0) {

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -127,15 +127,8 @@ module.exports = function (dir, keys) {
 
   const dmCache = {}
 
-  keys = {
-    curve: 'ed25519',
-    public: 'YmlfB1mzp2hRFIOCKRUlSm3JYY4+GQbtVg7XHdTSe8Q=.ed25519',
-    private: '8ZHH11uPnZRFAw2/XS7jDL3vQw+pGSnLF8jSOq0xK+RiaV8HWbOnaFEUg4IpFSVKbclhjj4ZBu1WDtcd1NJ7xA==.ed25519',
-    id: '@YmlfB1mzp2hRFIOCKRUlSm3JYY4+GQbtVg7XHdTSe8Q=.ed25519'
-  }
-  
   const buildDMKey = directMessageKey.easy(keys)
-  
+
   function sharedDMKey(author) {
     if (!dmCache[author])
       dmCache[author] = buildDMKey(authorId)
@@ -143,12 +136,9 @@ module.exports = function (dir, keys) {
     return dmCache[author]
   }
 
-  // can we derive this from seed?
+  // how do we derive this from seed?
   const ownKey = new SecretKey().toBuffer()
-  console.log(keys.id)
-  console.log(ownKey)
-  console.log(buildDMKey(keys.id))
-  
+
   function decryptBox2(ciphertext, author, previous) {
     const envelope = Buffer.from(ciphertext.replace('.box2', ''), 'base64')
     const feed_id = new FeedId(author).toTFK()

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -9,6 +9,10 @@ const DeferredPromise = require('p-defer')
 const path = require('path')
 const Debug = require('debug')
 
+const { unboxKey, unboxBody } = require('envelope-js')
+const directMessageKey = require('ssb-tribes/lib/direct-message-key')
+const SecretKey = require('ssb-tribes/lib/secret-key')
+
 const { indexesPath } = require('../defaults')
 
 module.exports = function (dir, keys) {
@@ -111,39 +115,119 @@ module.exports = function (dir, keys) {
   }
 
   const bValue = Buffer.from('value')
+  const bAuthor = Buffer.from('author')
+  const bPrevious = Buffer.from('previous')
   const bContent = Buffer.from('content')
+
+  function decryptBox2Msg(envelope, feed_id, prev_msg_id, read_key) {
+    const plaintext = unboxBody(envelope, feed_id, prev_msg_id, read_key)
+    if (plaintext) return JSON.parse(plaintext.toString('utf8'))
+    else return ''
+  }
+
+  const dmCache = {}
+
+  keys = {
+    curve: 'ed25519',
+    public: 'YmlfB1mzp2hRFIOCKRUlSm3JYY4+GQbtVg7XHdTSe8Q=.ed25519',
+    private: '8ZHH11uPnZRFAw2/XS7jDL3vQw+pGSnLF8jSOq0xK+RiaV8HWbOnaFEUg4IpFSVKbclhjj4ZBu1WDtcd1NJ7xA==.ed25519',
+    id: '@YmlfB1mzp2hRFIOCKRUlSm3JYY4+GQbtVg7XHdTSe8Q=.ed25519'
+  }
+  
+  const buildDMKey = directMessageKey.easy(keys)
+  
+  function sharedDMKey(author) {
+    if (!dmCache[author])
+      dmCache[author] = buildDMKey(authorId)
+
+    return dmCache[author]
+  }
+
+  // can we derive this from seed?
+  const ownKey = new SecretKey().toBuffer()
+  console.log(keys.id)
+  console.log(ownKey)
+  console.log(buildDMKey(keys.id))
+  
+  function decryptBox2(ciphertext, author, previous) {
+    const envelope = Buffer.from(ciphertext.replace('.box2', ''), 'base64')
+    const feed_id = new FeedId(author).toTFK()
+    const prev_msg_id = new MsgId(previous).toTFK()
+
+    const trial_group_keys = keystore.author.groupKeys(author)
+
+    const trial_dm_keys = [
+      sharedDMKey(author),
+      ownKey,
+    ]
+
+    read_key = unboxKey(envelope, feed_id, prev_msg_id, trial_dm_keys, {
+      maxAttempts: 16,
+    })
+
+    if (read_key)
+      return decryptBox2Msg(envelope, feed_id, prev_msg_id, read_key)
+    else return ''
+  }
+
+  function decryptBox1(ciphertext, keys) {
+    return ssbKeys.unbox(ciphertext, keys)
+  }
+
+  function tryDecryptContent(ciphertext, recBuffer, pValue) {
+    let content = ''
+    if (ciphertext.endsWith('.box')) content = decryptBox1(ciphertext, keys)
+    else if (ciphertext.endsWith('.box2')) {
+      const pAuthor = bipf.seekKey(recBuffer, pValue, bAuthor)
+      if (pAuthor >= 0) {
+        const author = bipf.decode(recBuffer, pAuthor)
+        const pPrevious = bipf.seekKey(recBuffer, pValue, bPrevious)
+        if (pPrevious >= 0) {
+          const previousMsg = bipf.decode(recBuffer, pPrevious)
+          content = decryptBox2(ciphertext, author, previousMsg)
+        }
+      }
+    }
+    return content
+  }
 
   function decrypt(record, streaming) {
     const recOffset = record.offset
     const recBuffer = record.value
     let p = 0 // note you pass in p!
     if (bsb.eq(canDecrypt, recOffset) !== -1) {
-      p = bipf.seekKey(recBuffer, p, bValue)
-      if (p < 0) return record
-      p = bipf.seekKey(recBuffer, p, bContent)
-      if (p < 0) return record
+      const pValue = bipf.seekKey(recBuffer, p, bValue)
+      if (pValue < 0) return record
+      const pContent = bipf.seekKey(recBuffer, pValue, bContent)
+      if (pContent < 0) return record
 
-      const unboxedContent = ssbKeys.unbox(bipf.decode(recBuffer, p), keys)
-      if (!unboxedContent) return record
+      const ciphertext = bipf.decode(recBuffer, pContent)
+      const content = tryDecryptContent(ciphertext, recBuffer, pValue)
+      if (!content) return record
 
-      return reconstructMessage(record, unboxedContent)
-    } else if (recOffset > latestOffset.value) {
+      const originalMsg = reconstructMessage(record, content)
+      return originalMsg
+    } else if (recOffset > latestOffset.value || !streaming) {
       if (streaming) latestOffset.set(recOffset)
 
-      p = bipf.seekKey(recBuffer, p, bValue)
-      if (p < 0) return record
-      p = bipf.seekKey(recBuffer, p, bContent)
-      if (p < 0) return record
+      const pValue = bipf.seekKey(recBuffer, p, bValue)
+      if (pValue < 0) return record
+      const pContent = bipf.seekKey(recBuffer, pValue, bContent)
+      if (pContent < 0) return record
 
-      const type = bipf.getEncodedType(recBuffer, p)
+      const type = bipf.getEncodedType(recBuffer, pContent)
       if (type !== bipf.types.string) return record
 
-      encrypted.push(recOffset)
-      const unboxedContent = ssbKeys.unbox(bipf.decode(recBuffer, p), keys)
-      if (!unboxedContent) return record
+      if (streaming)
+        encrypted.push(recOffset)
+
+      const ciphertext = bipf.decode(recBuffer, pContent)
+      const content = tryDecryptContent(ciphertext, recBuffer, pValue)
+      if (!content) return record
 
       canDecrypt.push(recOffset)
-      return reconstructMessage(record, unboxedContent)
+      if (!streaming) saveIndexes(() => {})
+      return reconstructMessage(record, content)
     } else {
       return record
     }

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -24,6 +24,10 @@ module.exports = function (dir, config, keystore) {
   const debug = Debug('ssb:db2:private')
 
   const encryptedFile = path.join(indexesPath(dir), 'encrypted.index')
+  // an option is to cache the read keys instead of only where the
+  // messages are, this has an overhead around storage.  The
+  // performance of that is a decrease in unbox time to 50% of
+  // original for box1 and around 75% box2
   const canDecryptFile = path.join(indexesPath(dir), 'canDecrypt.index')
 
   function save(filename, arr) {

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -19,6 +19,7 @@ module.exports = function (dir, config, keystore) {
   const stateLoaded = DeferredPromise()
   let encrypted = []
   let canDecrypt = []
+  const sbotId = config.keys.id
 
   const debug = Debug('ssb:db2:private')
 
@@ -130,10 +131,9 @@ module.exports = function (dir, config, keystore) {
     const feed_id = new FeedId(author).toTFK()
     const prev_msg_id = new MsgId(previous).toTFK()
 
-    const trial_dm_keys = [
-      keystore.sharedDMKey(author),
-      ...keystore.ownDMKeys()
-    ]
+    const trial_dm_keys = author !== sbotId ?
+          [keystore.sharedDMKey(author), ...keystore.ownDMKeys()] :
+          keystore.ownDMKeys()
 
     read_key = unboxKey(envelope, feed_id, prev_msg_id, trial_dm_keys, {
       maxAttempts: 16,

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -9,8 +9,9 @@ const DeferredPromise = require('p-defer')
 const path = require('path')
 const Debug = require('debug')
 
+const { FeedId, MsgId } = require('ssb-tribes/lib/cipherlinks')
 const { unboxKey, unboxBody } = require('envelope-js')
-const { ownKey, sharedDMKey } = require('../keystore')
+const KeyStore = require('../keystore')
 
 const { indexesPath } = require('../defaults')
 
@@ -19,6 +20,8 @@ module.exports = function (dir, keys) {
   const stateLoaded = DeferredPromise()
   let encrypted = []
   let canDecrypt = []
+
+  let keystore = KeyStore(keys)
 
   const debug = Debug('ssb:db2:private')
 

--- a/keystore.js
+++ b/keystore.js
@@ -13,12 +13,19 @@ module.exports = function (keys) {
     return dmCache[author]
   }
 
-  // fetch seed and derive?
+  // FIXME: fetch seed and derive?
   const ownKey = new SecretKey().toBuffer()
+
+  // FIXME: maybe if a feed has a meta feed, then we can assume it
+  // does box2 as well
+  function supportsBox2(feedId) {
+    return feedId.endsWith('.bbfeed-v1') || feedId.endsWith('.fusion-v1')
+  }
 
   return {
     ownKey,
     TFKId: new FeedId(keys.id).toTFK(),
     sharedDMKey,
+    supportsBox2,
   }
 }

--- a/keystore.js
+++ b/keystore.js
@@ -1,30 +1,42 @@
 const directMessageKey = require('ssb-tribes/lib/direct-message-key')
 const SecretKey = require('ssb-tribes/lib/secret-key')
 const { FeedId } = require('ssb-tribes/lib/cipherlinks')
+const { keySchemes } = require('private-group-spec')
 
-module.exports = function (keys) {
+module.exports = function (config) {
   const dmCache = {}
 
-  const buildDMKey = directMessageKey.easy(keys)
+  const buildDMKey = directMessageKey.easy(config.keys)
 
   function sharedDMKey(author) {
-    if (!dmCache[author]) dmCache[author] = buildDMKey(authorId)
+    if (!dmCache[author]) dmCache[author] = buildDMKey(author)
 
-    return dmCache[author]
+    return {
+      key: dmCache[author],
+      scheme: keySchemes.feed_id_dm,
+    }
   }
 
   // FIXME: fetch seed and derive?
-  const ownKey = new SecretKey().toBuffer()
+  const FIXMEKEY = Buffer.from(
+    '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
+    'hex'
+  )
+  const ownKey = {
+    key: FIXMEKEY, //new SecretKey().toBuffer(),
+    scheme: keySchemes.feed_id_self,
+  }
 
   // FIXME: maybe if a feed has a meta feed, then we can assume it
   // does box2 as well
   function supportsBox2(feedId) {
-    return feedId.endsWith('.bbfeed-v1') || feedId.endsWith('.fusion-v1')
+    if (config.db2 && config.db2.alwaysbox2) return true
+    else return feedId.endsWith('.bbfeed-v1') || feedId.endsWith('.fusion-v1')
   }
 
   return {
     ownKey,
-    TFKId: new FeedId(keys.id).toTFK(),
+    TFKId: new FeedId(config.keys.id).toTFK(),
     sharedDMKey,
     supportsBox2,
   }

--- a/keystore.js
+++ b/keystore.js
@@ -17,16 +17,6 @@ module.exports = function (config) {
     }
   }
 
-  // FIXME: fetch seed and derive?
-  const FIXMEKEY = Buffer.from(
-    '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
-    'hex'
-  )
-  const ownKey = {
-    key: FIXMEKEY, //new SecretKey().toBuffer(),
-    scheme: keySchemes.feed_id_self,
-  }
-
   // FIXME: maybe if a feed has a meta feed, then we can assume it
   // does box2 as well
   function supportsBox2(feedId) {
@@ -34,10 +24,23 @@ module.exports = function (config) {
     else return feedId.endsWith('.bbfeed-v1') || feedId.endsWith('.fusion-v1')
   }
 
+  let ownKeys = []
+
+  function addBox2DMKey(key) {
+    ownKeys.push(key)
+  }
+
+  function ownDMKeys() {
+    return ownKeys.map((key) => {
+      return { key, scheme: keySchemes.feed_id_self }
+    })
+  }
+
   return {
-    ownKey,
+    ownDMKeys,
     TFKId: new FeedId(config.keys.id).toTFK(),
     sharedDMKey,
     supportsBox2,
+    addBox2DMKey,
   }
 }

--- a/keystore.js
+++ b/keystore.js
@@ -1,7 +1,8 @@
 const directMessageKey = require('ssb-tribes/lib/direct-message-key')
 const SecretKey = require('ssb-tribes/lib/secret-key')
+const { FeedId } = require('ssb-tribes/lib/cipherlinks')
 
-module.exports = function () {
+module.exports = function (keys) {
   const dmCache = {}
 
   const buildDMKey = directMessageKey.easy(keys)
@@ -17,6 +18,7 @@ module.exports = function () {
 
   return {
     ownKey,
+    TFKId: new FeedId(keys.id).toTFK(),
     sharedDMKey,
   }
 }

--- a/keystore.js
+++ b/keystore.js
@@ -1,0 +1,22 @@
+const directMessageKey = require('ssb-tribes/lib/direct-message-key')
+const SecretKey = require('ssb-tribes/lib/secret-key')
+
+module.exports = function () {
+  const dmCache = {}
+
+  const buildDMKey = directMessageKey.easy(keys)
+
+  function sharedDMKey(author) {
+    if (!dmCache[author]) dmCache[author] = buildDMKey(authorId)
+
+    return dmCache[author]
+  }
+
+  // fetch seed and derive?
+  const ownKey = new SecretKey().toBuffer()
+
+  return {
+    ownKey,
+    sharedDMKey,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "binary-search-bounds": "^2.0.4",
     "bipf": "~1.5.0",
     "debug": "~4.3.1",
+    "envelope-js": "^1.0.0",
     "fastintcompression": "0.0.4",
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
@@ -38,6 +39,7 @@
     "ssb-keys": "^8.1.0",
     "ssb-ref": "^2.14.3",
     "ssb-sort": "^1.1.3",
+    "ssb-tribes": "^2.0.1",
     "ssb-validate": "^4.1.3",
     "too-hot": "^1.0.0",
     "typedarray-to-buffer": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "p-defer": "^3.0.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
+    "private-group-spec": "^1.0.0",
     "promisify-4loc": "1.0.0",
     "pull-async-filter": "^1.0.0",
     "pull-cat": "^1.1.11",

--- a/test/private.js
+++ b/test/private.js
@@ -50,3 +50,65 @@ test('publish: auto encrypt message with recps', (t) => {
     })
   })
 })
+
+test('box2', (t) => {
+  let content = { type: 'post', text: 'super secret', recps: [keys.id] }
+
+  const dirBox2 = '/tmp/ssb-db2-private-box2'
+  rimraf.sync(dirBox2)
+  mkdirp.sync(dirBox2)
+
+  const sbotBox2 = SecretStack({ appKey: caps.shs }).use(require('../')).call(null, {
+    keys,
+    path: dirBox2,
+    db2: {
+      alwaysbox2: true
+    }
+  })
+
+  sbotBox2.db.publish(content, (err, privateMsg) => {
+    t.error(err, 'no err')
+
+    t.true(privateMsg.value.content.endsWith(".box2"), 'box2 encoded')
+    sbotBox2.db.get(privateMsg.key, (err, msg) => {
+      t.error(err, 'no err')
+      t.equal(msg.content.text, 'super secret')
+
+      // encrypt to another key
+
+      const keys2 = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+      const dirKeys2 = '/tmp/ssb-db2-private-box2-2'
+      rimraf.sync(dirKeys2)
+      mkdirp.sync(dirKeys2)
+
+      const sbotKeys2 = SecretStack({ appKey: caps.shs }).use(require('../')).call(null, {
+        keys: keys2,
+        path: dirKeys2,
+        db2: {
+          alwaysbox2: true
+        }
+      })
+
+      let contentKeys2 = { type: 'post', text: 'keys2 secret', recps: [keys2.id] }
+
+      sbotBox2.db.publish(contentKeys2, (err, privateKeys2Msg) => {
+        sbotKeys2.db.add(privateMsg.value, (err) => {
+          sbotKeys2.db.add(privateKeys2Msg.value, (err) => {
+            t.error(err, 'no err')
+            sbotKeys2.db.get(privateKeys2Msg.key, (err, msg) => {
+              t.error(err, 'no err')
+              t.equal(msg.content.text, 'keys2 secret')
+
+              sbotKeys2.db.get(privateMsg.key, (err, msg) => {
+                t.error(err, 'no err')
+                t.true(privateMsg.value.content.endsWith(".box2"), 'box2 encoded')
+
+                sbotBox2.close(() => sbotKeys2.close(t.end))
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/private.js
+++ b/test/private.js
@@ -52,7 +52,10 @@ test('publish: auto encrypt message with recps', (t) => {
 })
 
 test('box2', (t) => {
-  let content = { type: 'post', text: 'super secret', recps: [keys.id] }
+  const testkey = Buffer.from(
+    '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
+    'hex'
+  )
 
   const dirBox2 = '/tmp/ssb-db2-private-box2'
   rimraf.sync(dirBox2)
@@ -66,6 +69,10 @@ test('box2', (t) => {
     }
   })
 
+  sbotBox2.db.addBox2DMKey(testkey)
+
+  let content = { type: 'post', text: 'super secret', recps: [keys.id] }
+
   sbotBox2.db.publish(content, (err, privateMsg) => {
     t.error(err, 'no err')
 
@@ -76,10 +83,11 @@ test('box2', (t) => {
 
       // encrypt to another key
 
-      const keys2 = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
       const dirKeys2 = '/tmp/ssb-db2-private-box2-2'
       rimraf.sync(dirKeys2)
       mkdirp.sync(dirKeys2)
+
+      const keys2 = ssbKeys.loadOrCreateSync(path.join(dirKeys2, 'secret'))
 
       const sbotKeys2 = SecretStack({ appKey: caps.shs }).use(require('../')).call(null, {
         keys: keys2,


### PR DESCRIPTION
This is work in progress, the idea is to merge this into the [bendy butt branch](https://github.com/ssb-ngi-pointer/ssb-db2/pull/231) as we would like to use box2 for that, but also for fusion identities.

@mixmix some numbers for you

```
# add a bunch of messages
ok 1 duration: 162ms
# private
ok 2 box duration: 916ms
ok 3 unbox first run duration: 289ms
ok 4 unbox second run duration: 103ms
# private box2
ok 5 box duration: 392ms
ok 6 unbox duration first run: 433ms
ok 7 unbox duration second run: 145ms
```