### PR TITLE
Fix updateIndexes to account for private index progress

### DIFF
--- a/db.js
+++ b/db.js
@@ -16,15 +16,8 @@ const makeBaseIndex = require('./indexes/base')
 const KeysIndex = require('./indexes/keys')
 const PrivateIndex = require('./indexes/private')
 
-const {
-  where,
-  fromDB,
-  key,
-  author,
-  deferred,
-  toCallback,
-  asOffsets,
-} = operators
+const { where, fromDB, key, author, deferred, toCallback, asOffsets } =
+  operators
 
 exports.name = 'db'
 
@@ -299,7 +292,10 @@ exports.init = function (sbot, config) {
 
     const indexesArr = Object.values(indexes)
 
-    const lowestOffset = Math.min(...indexesArr.map((idx) => idx.offset.value))
+    const lowestOffset = Math.min(
+      ...indexesArr.map((idx) => idx.offset.value),
+      privateIndex.latestOffset.value
+    )
     debug(`lowest offset for all indexes is ${lowestOffset}`)
 
     log.stream({ gt: lowestOffset }).pipe({

--- a/test/migration.js
+++ b/test/migration.js
@@ -150,7 +150,7 @@ test('migrate keeps new log synced with ssb-db being updated', (t) => {
   )
 })
 
-test('migrate does not read decrypted from old log', (t) => {
+test('test migrate with encrypted messages', (t) => {
   const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
   const sbot = SecretStack({ appKey: caps.shs })
     .use(require('ssb-db'))
@@ -175,8 +175,8 @@ test('migrate does not read decrypted from old log', (t) => {
       where(and(type('post'), isPrivate())),
       toCallback((err, msgs) => {
         t.error(err, 'no err')
-        t.equal(msgs.length, 1)
-        t.equal(msgs[0].value.content.text, 'super secret')
+        t.equal(msgs.length, 2)
+        t.equal(msgs[1].value.content.text, 'super secret')
         sbot.close(t.end)
       })
     )


### PR DESCRIPTION
So I was hunting down the [flaky bug](https://github.com/ssb-ngi-pointer/ssb-meta-feeds/issues/13) in ssb-meta-feeds tests. What I was seeing was that it was failing the restart test. The reason it was failing the restart test was because the save function in private saves every [1 second](https://github.com/ssb-ngi-pointer/ssb-db2/blob/b918e59bd31fa60392b17276aa4b0d3b751feb83/indexes/private.js#L88) while other indexes more often. And that meant that once the restart test started up, there was no private index. This shouldn't have been a problem as it should have been regenerated before the query ran, but the `updateIndexes` function had a bug where it did not take into account the private index, which meant that the decrypt function in the private index was given a starting point that was higher than its own latest sequence, so it was [missing](https://github.com/ssb-ngi-pointer/ssb-db2/blob/b918e59bd31fa60392b17276aa4b0d3b751feb83/indexes/private.js#L131) encrypted messages (in this case the seed). I was trying to write a small test to reproduce the problem but found that there actually already was a test for this ;) The migration tests had a test that from the name looks like it should only get 1 message, the newly created message, but actually the fixture generation had already created 1 private message for the owner of the database, and that message should of course be decrypted in db2 world. 

Some debug:

secret stack keys.id = '@ck+PSnGmdeWbpmU6SRvCLAK1BGHZ3knueso9AS1Kz20=.ed25519'

Messages from the fixture with recps:

```
  {
    author: '@ck+PSnGmdeWbpmU6SRvCLAK1BGHZ3knueso9AS1Kz20=.ed25519',
    content: {
      type: 'post',
      text: 'Deserunt fugiat aliqua aliquip aute laboris qui enim cupidatat incididunt cillum id eu consectetur labore nostrud. Fugiat non adipisicing proident qui reprehenderit quis sunt laboris cillum. Esse veniam irure magna sit ullamco reprehenderit nisi officia aliquip magna dolor fugiat duis commodo. Officia amet do nulla veniam laborum elit enim commodo id nisi commodo. Veniam cillum commodo sint aliqua sit.',
      recps: [
      '@ck+PSnGmdeWbpmU6SRvCLAK1BGHZ3knueso9AS1Kz20=.ed25519',
      '@F5hUOhoPODcd6W+w4LTI2rtHYq66qAg/wtQ1XrWSMX8=.ed25519',
      '@a5URnr0bEtVFmNxQu/JwQ5JsfEl+HAPz5ethL+I1CCA=.ed25519',
      '@B5fby7f2oZQfLJVQFpkxzh616WxS9ia5f+4Qm93o75g=.ed25519'
    ]
    }
  }
```

So I changed that test so that it actually works and we can use that test for this fix ;-) It might still be a good idea to write another migration test for what is was supposed to test, but it is getting late here.