### PR TITLE
Validate2 review changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,10 +377,11 @@ partial replication.
 
 ### addOOOBatch(msgValues, cb)
 
-Similar to `addOOO`, but you can pass an array of many message values. If the
-author is not yet known, the message is validated without checking if the
-previous link is correct, otherwise normal validation. This makes it possible to
-use for partial replication to add say latest 25 messages from a feed.
+Similar to `addOOO`, but you can pass an array of many message
+values. If the author is not yet known, the message is validated
+without checking if the previous link is correct, otherwise normal
+validation. This makes it possible to use for partial replication to
+add all contact messages from a feed.
 
 ### getStatus
 

--- a/db.js
+++ b/db.js
@@ -214,13 +214,12 @@ exports.init = function (sbot, config) {
             if (i === msgVals.length - 1) {
               // last KVT, let's update the latest state
               updateState({ key: keys[i], value: msgVals[i] })
-              log.add(keys[i], msgVals[i], (err, kvt) => {
-                post.set(kvt)
-                done()(err, kvt)
-              })
-            } else {
-              log.add(keys[i], msgVals[i], done())
             }
+
+            log.add(keys[i], msgVals[i], (err, kvt) => {
+              post.set(kvt)
+              done()(err, kvt)
+            })
           }
 
           done(cb)
@@ -481,6 +480,7 @@ exports.init = function (sbot, config) {
     publish,
     addOOO,
     addOOOBatch,
+    setPost: post.set,
     getStatus: () => status.obv,
     operators,
     post,

--- a/db.js
+++ b/db.js
@@ -211,14 +211,17 @@ exports.init = function (sbot, config) {
 
           const done = multicb({ pluck: 1 })
           for (var i = 0; i < msgVals.length; ++i) {
-            if (i === msgVals.length - 1) {
-              // last KVT, let's update the latest state
-              updateState({ key: keys[i], value: msgVals[i] })
-            }
+            const isLast = i === msgVals.length - 1
 
             log.add(keys[i], msgVals[i], (err, kvt) => {
+              if (err) return done()(err)
+
+              if (isLast) {
+                // last KVT, let's update the latest state
+                updateState({ key: keys[i], value: msgVals[i] })
+              }
               post.set(kvt)
-              done()(err, kvt)
+              done()(null, kvt)
             })
           }
 
@@ -241,9 +244,10 @@ exports.init = function (sbot, config) {
           : null
         validate2.validateSingle(hmacKey, msgVal, latestMsgVal, (err, key) => {
           if (err) return cb(err)
-          updateState({ key, value: msgVal })
           log.add(key, msgVal, (err, kvt) => {
             if (err) return cb(err)
+
+            updateState({ key, value: msgVal })
             post.set(kvt)
             cb(null, kvt)
           })
@@ -290,10 +294,12 @@ exports.init = function (sbot, config) {
           Date.now()
         )
         const kvt = validate.toKeyValueTimestamp(msgVal)
-        updateState(kvt)
         log.add(kvt.key, kvt.value, (err, data) => {
+          if (err) return cb(err)
+
+          updateState(kvt)
           post.set(data)
-          cb(err, data)
+          cb(null, data)
         })
       }
     )
@@ -480,10 +486,12 @@ exports.init = function (sbot, config) {
     publish,
     addOOO,
     addOOOBatch,
-    setPost: post.set,
     getStatus: () => status.obv,
     operators,
     post,
+
+    // used for partial replication in browser, will be removed soon!
+    setPost: post.set,
 
     // needed primarily internally by other plugins in this project:
     addBatch,

--- a/db.js
+++ b/db.js
@@ -213,8 +213,9 @@ exports.init = function (sbot, config) {
           for (var i = 0; i < msgVals.length; ++i) {
             if (i === msgVals.length - 1) {
               // last KVT, let's update the latest state
+              updateState({ key: keys[i], value: msgVals[i] })
               log.add(keys[i], msgVals[i], (err, kvt) => {
-                if (!err && kvt) updateState(kvt)
+                post.set(kvt)
                 done()(err, kvt)
               })
             } else {
@@ -242,10 +243,10 @@ exports.init = function (sbot, config) {
         validate2.validateSingle(hmacKey, msgVal, latestMsgVal, (err, key) => {
           if (err) return cb(err)
           updateState({ key, value: msgVal })
-          log.add(key, msgVal, (err, data) => {
+          log.add(key, msgVal, (err, kvt) => {
             if (err) return cb(err)
-            post.set(data)
-            cb(null, data)
+            post.set(kvt)
+            cb(null, kvt)
           })
         })
       }
@@ -266,7 +267,6 @@ exports.init = function (sbot, config) {
         if (data) return cb(null, data)
         log.add(key, msgVal, (err, data) => {
           if (err) return cb(err)
-          post.set(data)
           cb(null, data)
         })
       })

--- a/db.js
+++ b/db.js
@@ -216,10 +216,7 @@ exports.init = function (sbot, config) {
             log.add(keys[i], msgVals[i], (err, kvt) => {
               if (err) return done()(err)
 
-              if (isLast) {
-                // last KVT, let's update the latest state
-                updateState({ key: keys[i], value: msgVals[i] })
-              }
+              if (isLast) updateState(kvt)
               post.set(kvt)
               done()(null, kvt)
             })

--- a/db.js
+++ b/db.js
@@ -252,7 +252,7 @@ exports.init = function (sbot, config) {
     )
   }
 
-  const debouncePeriod = config.db2.addDebounce || 400
+  const debouncePeriod = config.db2.addDebounce || 250
   const debouncer = new DebouncingBatchAdd(addBatch, debouncePeriod)
 
   function addOOO(msgVal, cb) {

--- a/db.js
+++ b/db.js
@@ -3,7 +3,7 @@ const ssbKeys = require('ssb-keys')
 const validate = require('ssb-validate') // TODO: remove this eventually
 const validate2 =
   typeof localStorage === 'undefined' || localStorage === null
-    ? require('ssb-validate2-rsjs')
+    ? require('ssb-validate2-rsjs-node')
     : require('ssb-validate2')
 const bipf = require('bipf')
 const pull = require('pull-stream')

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ssb-sort": "^1.1.3",
     "ssb-validate": "^4.1.3",
     "ssb-validate2": "~0.1.1",
-    "ssb-validate2-rsjs": "~0.6.0",
+    "ssb-validate2-rsjs-node": "~0.6.0",
     "too-hot": "^1.0.0",
     "typedarray-to-buffer": "^4.0.0"
   },

--- a/test/validate.js
+++ b/test/validate.js
@@ -93,6 +93,8 @@ test('Raw feed with unused type + ooo in batch', (t) => {
     Date.now() + 5
   )
 
+  const latestPost = db.post.value
+
   const msgVals = state.queue.slice(2).map((msg) => msg.value)
   db.addOOOBatch(msgVals, (err) => {
     t.error(err, 'no err')
@@ -100,6 +102,7 @@ test('Raw feed with unused type + ooo in batch', (t) => {
     db.addOOO(state.queue[0].value, (err, oooMsg) => {
       t.error(err, 'no err')
       t.equal(oooMsg.value.content.text, 'test1', 'text correct')
+      t.equal(db.post.value, latestPost, 'ooo methods does update post') // as that would break EBT
 
       t.end()
     })

--- a/test/validate.js
+++ b/test/validate.js
@@ -102,7 +102,7 @@ test('Raw feed with unused type + ooo in batch', (t) => {
     db.addOOO(state.queue[0].value, (err, oooMsg) => {
       t.error(err, 'no err')
       t.equal(oooMsg.value.content.text, 'test1', 'text correct')
-      t.equal(db.post.value, latestPost, 'ooo methods does update post') // as that would break EBT
+      t.equal(db.post.value, latestPost, 'ooo methods does not update post') // as that would break EBT
 
       t.end()
     })


### PR DESCRIPTION
This is my review of https://github.com/ssb-ngi-pointer/ssb-db2/pull/236. I have put it into ssb-browser and did quite a few tests. Initially I had the same `asyncMap(sbot.db.add)` so that part was really slow like the tests. Not sure how to best avoid that gotcha. 

It is probably easiest to read this as the individual commits, the first two are rather simple. The next 2 is about making sure that post.set works correctly in all cases. post.set is used to "communicate" with ebt and before there was a bug where `addBatch` did not call `post.set`. Furthermore the ooo methods must never call that function, unless they are at the head of the feed (this is why I added setPost, secretstack seems to hook that object / function into oblivion). In general I'm not super happy about the way this post is used between these modules, a bit too magic. For the sake of backwards compatibility I think we should probably leave it as is.

The last commit changes our dependency to rsjs-node directly so that we don't try to compile the wasm module as it is currently not used (at least not in the browser).