### PR TITLE
Remove publishAs() for meta feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,23 +358,25 @@ this method unless you know exactly what you are doing.
 Delete all messages of a specific feedId. Compared to `del` this
 method is safe to use.
 
-### publish(msg, cb)
+### publish(content, cb)
 
-Convenience method for validating and adding a message to the database
-written by the feed running the secret-stack. If message contains
-recps, the message will automatically be encrypted.
+Convenience method for validating and adding a classic SSB message to
+the database written by the feed running the secret-stack. If message
+`content` contains recps, the message will automatically be encrypted.
 
-### publishAs(feedKey, msg, cb)
+### publishAs(feedKeys, content, cb)
 
-Convenience method for validating and adding a message to the database
-written by a different feed than running the secret-stack. If message
-contains recps, the message will automatically be encrypted.
+Convenience method for validating and adding a classic SSB message to
+the database written by a different feed than running the secret-stack.
+If message `content` contains recps, the message will automatically be
+encrypted.
 
-### add(msg, cb)
+### add(msgVal, cb)
 
 Validate and add a message value (without id and timestamp) to the
 database. In the callback will be the stored message (id, timestamp,
-value = original message) or err.
+value = `msgVal`) or err. Supports `msgVal` in SSB classic feeds as
+well as [Bendy Butt] messages
 
 ### addOOOStrictOrder(msg, cb)
 
@@ -447,4 +449,5 @@ const config = {
 [ssb-db]: https://github.com/ssbc/ssb-db/
 [bipf]: https://github.com/ssbc/bipf/
 [jitdb]: https://github.com/ssb-ngi-pointer/jitdb/
+[Bendy Butt]: https://github.com/ssb-ngi-pointer/ssb-bendy-butt
 [ssb-social-index]: https://github.com/ssbc/ssb-social-index

--- a/db.js
+++ b/db.js
@@ -269,18 +269,18 @@ exports.init = function (sbot, config) {
     else if (keys.id.endsWith('.bbfeed-v1')) {
       const msgVal = x
 
-      // FIXME: validate
-
       onceWhen(
         stateFeedsReady,
         (ready) => ready === true,
         () => {
+          const previous = (state.feeds[keys.id] || { value: null }).value
+          const err = bendyButt.validateSingle(msgVal, previous, hmac_key)
+          if (err) return cb(err)
+
           const msgKey = bendyButt.hash(msgVal)
           state.feeds[keys.id] = {
             id: msgKey,
-            timestamp: msgVal.timestamp,
-            sequence: msgVal.sequence,
-            queue: [],
+            value: msgVal,
           }
 
           log.add(msgKey, msgVal, (err, data) => {

--- a/db.js
+++ b/db.js
@@ -283,7 +283,7 @@ exports.init = function (sbot, config) {
           })
         }
       )
-    } else throw ('Unknown feed format', keys)
+    } else throw new Error('Unknown feed format: ' + keys.id)
   }
 
   function del(msgId, cb) {

--- a/db.js
+++ b/db.js
@@ -223,7 +223,13 @@ exports.init = function (sbot, config) {
         if (msg.recps) msg = ssbKeys.box(msg, msg.recps)
 
         state.queue = []
-        state = validate.appendNew(state, hmac_key, config.keys, msg, Date.now())
+        state = validate.appendNew(
+          state,
+          hmac_key,
+          config.keys,
+          msg,
+          Date.now()
+        )
 
         const kv = state.queue[state.queue.length - 1]
         log.add(kv.key, kv.value, (err, data) => {

--- a/db.js
+++ b/db.js
@@ -248,15 +248,14 @@ exports.init = function (sbot, config) {
         (ready) => ready === true,
         () => {
           if (content.recps) content = ssbKeys.box(content, content.recps)
-
-          state.queue = []
-          state = validate.appendNew(state, hmac_key, keys, content, Date.now())
-
-          const kv = state.queue[state.queue.length - 1]
-          log.add(kv.key, kv.value, (err, data) => {
-            post.set(data)
-            cb(err, data)
-          })
+          const msgVal = validate.create(
+            state.feeds[keys.id],
+            keys,
+            hmac_key,
+            content,
+            Date.now()
+          )
+          add(msgVal, cb)
         }
       )
     } else {

--- a/db.js
+++ b/db.js
@@ -223,7 +223,7 @@ exports.init = function (sbot, config) {
         if (msg.recps) msg = ssbKeys.box(msg, msg.recps)
 
         state.queue = []
-        state = validate.appendNew(state, null, config.keys, msg, Date.now())
+        state = validate.appendNew(state, hmac_key, config.keys, msg, Date.now())
 
         const kv = state.queue[state.queue.length - 1]
         log.add(kv.key, kv.value, (err, data) => {
@@ -249,7 +249,7 @@ exports.init = function (sbot, config) {
           if (content.recps) content = ssbKeys.box(content, content.recps)
 
           state.queue = []
-          state = validate.appendNew(state, null, keys, content, Date.now())
+          state = validate.appendNew(state, hmac_key, keys, content, Date.now())
 
           const kv = state.queue[state.queue.length - 1]
           log.add(kv.key, kv.value, (err, data) => {

--- a/db.js
+++ b/db.js
@@ -1,5 +1,6 @@
 const push = require('push-stream')
 const ssbKeys = require('ssb-keys')
+const Ref = require('ssb-ref')
 const validate = require('ssb-validate')
 const Obv = require('obz')
 const promisify = require('promisify-4loc')
@@ -245,8 +246,7 @@ exports.init = function (sbot, config) {
     if (guard) return cb(guard)
 
     // Classic SSB Feed
-    if (keys.id.endsWith('.ed25519')) {
-      // FIXME: this endsWith check should be a ssb-ref concern
+    if (Ref.isFeedId(keys.id)) {
       const content = x
       onceWhen(
         stateFeedsReady,

--- a/db.js
+++ b/db.js
@@ -234,28 +234,7 @@ exports.init = function (sbot, config) {
     const guard = guardAgainstDuplicateLogs('publish()')
     if (guard) return cb(guard)
 
-    onceWhen(
-      stateFeedsReady,
-      (ready) => ready === true,
-      () => {
-        if (content.recps) content = ssbKeys.box(content, content.recps)
-
-        state.queue = []
-        state = validate.appendNew(
-          state,
-          hmac_key,
-          config.keys,
-          content,
-          Date.now()
-        )
-
-        const kv = state.queue[state.queue.length - 1]
-        log.add(kv.key, kv.value, (err, data) => {
-          post.set(data)
-          cb(err, data)
-        })
-      }
-    )
+    publishAs(config.keys, content, cb)
   }
 
   function publishAs(keys, content, cb) {

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -29,7 +29,7 @@ module.exports = function (dir, keys) {
     buf.copy(b, 4)
 
     writeFile(filename, b, (err) => {
-      if (err) debug("failed to save file %o, got error %o", filename, err)
+      if (err) debug('failed to save file %o, got error %o', filename, err)
     })
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -327,46 +327,6 @@ test('publishAs classic', (t) => {
   })
 })
 
-test('publishAs bendy butt', (t) => {
-  // fake some keys
-  const mfKeys = ssbKeys.generate()
-  mfKeys.id = mfKeys.id.replace('.ed25519', '.bbfeed-v1')
-  const mainKeys = ssbKeys.generate()
-
-  const content = {
-    type: 'metafeed/add/existing',
-    feedpurpose: 'main',
-    subfeed: mainKeys.id,
-    metafeed: mfKeys.id,
-    tangles: {
-      metafeed: {
-        root: null,
-        previous: null,
-      },
-    },
-  }
-
-  const sequence = 1
-  const previous = null
-  const timestamp = Date.now()
-
-  const bbmsg = bendyButt.encodeNew(
-    content,
-    mainKeys,
-    mfKeys,
-    sequence,
-    previous,
-    timestamp
-  )
-  const msgVal = bendyButt.decode(bbmsg)
-
-  db.publishAs(mfKeys, msgVal, (err, msg) => {
-    t.error(err, 'no err')
-
-    db.get(msg.key, (err, msg) => {
-      t.equal(msg.sequence, 1, 'sequence ok')
-      t.equal(msg.content.type, 'metafeed/add/existing')
-      sbot.close(t.end)
-    })
-  })
+test('teardown', (t) => {
+  sbot.close(t.end)
 })

--- a/test/basic.js
+++ b/test/basic.js
@@ -248,7 +248,7 @@ test('validate needs to load', (t) => {
 test('publishAs classic', (t) => {
   const keys = ssbKeys.generate()
 
-  const content = { type: "post", text: "hello world!" }
+  const content = { type: 'post', text: 'hello world!' }
 
   db.publishAs(keys, content, (err, msg) => {
     t.error(err, 'no err')
@@ -263,20 +263,20 @@ test('publishAs classic', (t) => {
 test('publishAs bendy butt', (t) => {
   // fake some keys
   const mfKeys = ssbKeys.generate()
-  mfKeys.id = mfKeys.id.replace(".ed25519", ".bbfeed-v1")
+  mfKeys.id = mfKeys.id.replace('.ed25519', '.bbfeed-v1')
   const mainKeys = ssbKeys.generate()
 
   const content = {
-    type: "metafeed/add/existing",
-    feedpurpose: "main",
+    type: 'metafeed/add/existing',
+    feedpurpose: 'main',
     subfeed: mainKeys.id,
     metafeed: mfKeys.id,
     tangles: {
       metafeed: {
         root: null,
-        previous: null
-      }
-    }
+        previous: null,
+      },
+    },
   }
 
   const sequence = 1

--- a/test/basic.js
+++ b/test/basic.js
@@ -267,7 +267,7 @@ test('publishAs bendy butt', (t) => {
   const mainKeys = ssbKeys.generate()
 
   const content = {
-    type: "metafeed/add",
+    type: "metafeed/add/existing",
     feedpurpose: "main",
     subfeed: mainKeys.id,
     metafeed: mfKeys.id,
@@ -298,7 +298,7 @@ test('publishAs bendy butt', (t) => {
 
     db.get(msg.key, (err, msg) => {
       t.equal(msg.sequence, 1, 'sequence ok')
-      t.equal(msg.content.type, 'metafeed/add')
+      t.equal(msg.content.type, 'metafeed/add/existing')
       sbot.close(t.end)
     })
   })

--- a/test/ebt.js
+++ b/test/ebt.js
@@ -72,8 +72,7 @@ test('Encrypted', (t) => {
   let i = 0
 
   var remove = sbot.db.post((msg) => {
-    if (i++ === 0)
-      t.equal(msg.value.sequence, 3, 'we get existing')
+    if (i++ === 0) t.equal(msg.value.sequence, 3, 'we get existing')
     else {
       t.equal(msg.value.sequence, 4, 'post is called on publish')
       remove()
@@ -106,8 +105,7 @@ test('add', (t) => {
   let i = 0
 
   var remove = sbot.db.post((msg) => {
-    if (i++ === 0)
-      t.equal(msg.value.author, keys.id, 'we get existing')
+    if (i++ === 0) t.equal(msg.value.author, keys.id, 'we get existing')
     else {
       t.equal(msg.value.author, keys2.id, 'post is called on add')
       remove()


### PR DESCRIPTION
@arj03 This PR targets `publishAs-simple` because I didn't want to push to that branch directly. Reviewing commit-per-commit is probably easiest.

This PR surprisingly is *removing* support for bendy butt in `publishAs()` but bear with me: I progressively realized that "wait, we don't need this" and then "we don't need that either", and deleted code until it got to this state.

If we put bendy butt validation in `publishAs()` (as the FIXME said) **and** implement support for bendy butt in `add()`, the two functions end up looking exactly the same (for the bendy butt part), and that's because both of them accept a `msgVal`, validate it, update state, and add it to the log.

So I removed support for bendy butt in `publishAs()`, and when you think about it, it makes sense because the bendy butt ID used is always different to `config.keys` ID, and that sounds like a use case for `add()`. I took a look in `ssb-meta-feeds`, and we could easily use `ssb.db.add(bendyButtMsgVal)` over there.

I guess this ties back to your question whether `bendyButt.encodeNew` should be inside `publishAs()`. Basically it *could*, but that would require moving a ton of code from ssb-meta-feeds into ssb-db2, and I'm not sure that's useful or easy to understand. Basically, semantically, `publish()` is always "give me **content**, and I will wrap it in a msgVal".

In the future, we could consider moving "classic content to classic msgVal" algorithm to a module `ssb-classic-feed` which would be similar to `ssb-bendy-butt` in responsibility, so that ssb-db2 doesn't need to make hard assumptions anymore.

Finally, this PR also simplified `publish()` because we can implement it in terms of `publishAs()`. The only difference between the implementation of those two turned out to be just one variable. And then also `publishAs()` internally calls `add()`.

I ran tests locally and they passed :heavy_check_mark: (CI is not configured to run for branches-of-branches), but it might be a good idea to run them yourself locally.