### PR TITLE
add package.json files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "type": "git",
     "url": "git@github.com:ssb-ngi-pointer/ssb-db2.git"
   },
+  "files": [
+    "*.js",
+    "compat/*.js",
+    "indexes/*.js",
+    "operators/*.js"
+  ],
   "dependencies": {
     "async-append-only-log": "^3.0.8",
     "atomic-file-rw": "^0.2.1",


### PR DESCRIPTION
You can see I discovered a new toy

## Before

```
npm notice 
npm notice 📦  ssb-db2@2.1.5
npm notice === Tarball Contents === 
npm notice 1.5kB  .github/workflows/node.js.yml
npm notice 17.1kB benchmark/index.js           
npm notice 643B   compat/db.js                 
npm notice 852B   compat/ebt.js                
npm notice 1.9kB  compat/history-stream.js     
npm notice 118B   compat/index.js              
npm notice 1.3kB  compat/log-stream.js         
npm notice 2.3kB  indexes/about-self.js        
npm notice 2.5kB  indexes/base.js              
npm notice 1.3kB  indexes/ebt.js               
npm notice 2.0kB  indexes/full-mentions.js     
npm notice 780B   indexes/keys.js              
npm notice 4.1kB  indexes/plugin.js            
npm notice 4.4kB  indexes/private.js           
npm notice 263B   operators/full-mentions.js   
npm notice 2.8kB  operators/index.js           
npm notice 3.2kB  test/about-self.js           
npm notice 2.3kB  test/base-index.js           
npm notice 6.1kB  test/basic.js                
npm notice 1.2kB  test/compat.js               
npm notice 5.5kB  test/createHistoryStream.js  
npm notice 3.0kB  test/createLogStream.js      
npm notice 1.5kB  test/delete.js               
npm notice 2.8kB  test/ebt.js                  
npm notice 2.7kB  test/full-mentions.js        
npm notice 1.5kB  test/migration-alone.js      
npm notice 8.1kB  test/migration.js            
npm notice 1.6kB  test/multiple-indexes.js     
npm notice 12.8kB test/operators.js            
npm notice 1.3kB  test/private.js              
npm notice 2.7kB  test/query-waits-migrate.js  
npm notice 6.4kB  test/validate.js             
npm notice 43B    .prettierrc                  
npm notice 139B   about-self.js                
npm notice 12.0kB db.js                        
npm notice 568B   defaults.js                  
npm notice 1.2kB  EXAMPLES.md                  
npm notice 254B   full-mentions.js             
npm notice 57B    index.js                     
npm notice 7.7kB  LICENSE                      
npm notice 2.2kB  log.js                       
npm notice 10.2kB migrate.js                   
npm notice 2.2kB  package.json                 
npm notice 14.2kB README.md                    
npm notice 3.5kB  seekers.js                   
npm notice 1.3kB  status.js                    
npm notice 492B   utils.js                     
npm notice === Tarball Details === 
npm notice name:          ssb-db2                                 
npm notice version:       2.1.5                                   
npm notice filename:      ssb-db2-2.1.5.tgz                       
npm notice package size:  36.7 kB                                 
npm notice unpacked size: 162.6 kB                                
npm notice shasum:        96d029af877bb1349f4f6b8a108fb0a87a932ee8
npm notice integrity:     sha512-60fws+JPwZJqE[...]+UyHIjB0TfX0Q==
npm notice total files:   47                                      
npm notice 
ssb-db2-2.1.5.tgz
```

## After

```
npm notice 
npm notice 📦  ssb-db2@2.1.5
npm notice === Tarball Contents === 
npm notice 643B   compat/db.js              
npm notice 852B   compat/ebt.js             
npm notice 1.9kB  compat/history-stream.js  
npm notice 118B   compat/index.js           
npm notice 1.3kB  compat/log-stream.js      
npm notice 2.3kB  indexes/about-self.js     
npm notice 2.5kB  indexes/base.js           
npm notice 1.3kB  indexes/ebt.js            
npm notice 2.0kB  indexes/full-mentions.js  
npm notice 780B   indexes/keys.js           
npm notice 4.1kB  indexes/plugin.js         
npm notice 4.4kB  indexes/private.js        
npm notice 263B   operators/full-mentions.js
npm notice 2.8kB  operators/index.js        
npm notice 139B   about-self.js             
npm notice 12.0kB db.js                     
npm notice 568B   defaults.js               
npm notice 254B   full-mentions.js          
npm notice 57B    index.js                  
npm notice 7.7kB  LICENSE                   
npm notice 2.2kB  log.js                    
npm notice 10.2kB migrate.js                
npm notice 2.3kB  package.json              
npm notice 14.2kB README.md                 
npm notice 3.5kB  seekers.js                
npm notice 1.3kB  status.js                 
npm notice 492B   utils.js                  
npm notice === Tarball Details === 
npm notice name:          ssb-db2                                 
npm notice version:       2.1.5                                   
npm notice filename:      ssb-db2-2.1.5.tgz                       
npm notice package size:  23.1 kB                                 
npm notice unpacked size: 80.0 kB                                 
npm notice shasum:        c233fcfb4569da214d4903cf5c016abc7fd8327c
npm notice integrity:     sha512-BJ9H7zAUKMndE[...]itlrOcOA0tNXQ==
npm notice total files:   27                                      
npm notice 
ssb-db2-2.1.5.tgz
```