### PR TITLE
Add more db1 compability methods

### DIFF
--- a/compat/db.js
+++ b/compat/db.js
@@ -10,7 +10,14 @@ exports.manifest = {
 
 exports.init = function (sbot, config) {
   sbot.add = sbot.db.add
-  sbot.get = sbot.db.get
+  sbot.get = function get(idOrObject, cb) {
+    if (typeof idOrObject === 'object' && idOrObject.meta)
+      sbot.db.getMsg(idOrObject.id, cb)
+    else if (typeof idOrObject === 'object')
+      sbot.db.get(idOrObject.id, cb)
+    else
+      sbot.db.get(idOrObject, cb)
+  }
   sbot.publish = sbot.db.publish
   sbot.whoami = () => ({ id: sbot.id })
   sbot.ready = () => true

--- a/compat/db.js
+++ b/compat/db.js
@@ -9,6 +9,7 @@ exports.manifest = {
 }
 
 exports.init = function (sbot, config) {
+  sbot.get = sbot.db.get
   sbot.publish = sbot.db.publish
   sbot.whoami = () => ({ id: sbot.id })
   sbot.ready = () => true

--- a/compat/db.js
+++ b/compat/db.js
@@ -9,6 +9,7 @@ exports.manifest = {
 }
 
 exports.init = function (sbot, config) {
+  sbot.add = sbot.db.add
   sbot.get = sbot.db.get
   sbot.publish = sbot.db.publish
   sbot.whoami = () => ({ id: sbot.id })

--- a/compat/feedstate.js
+++ b/compat/feedstate.js
@@ -1,0 +1,21 @@
+const { onceWhen } = require('../utils')
+
+exports.init = function (sbot, config) {
+  sbot.getFeedState = function(feedId, cb) {
+    onceWhen(
+      sbot.db.stateFeedsReady,
+      (ready) => ready === true,
+      () => {
+        const feedState = sbot.db.getState().feeds[feedId]
+
+        // this covers the case where you have a brand new feed
+        if (!feedState) return cb(null, { id: null, sequence: 0 })
+
+        return cb(null, {
+          id: feedState.id,
+          sequence: feedState.sequence
+        })
+      }
+    )
+  }
+}

--- a/compat/feedstate.js
+++ b/compat/feedstate.js
@@ -6,14 +6,14 @@ exports.init = function (sbot, config) {
       sbot.db.stateFeedsReady,
       (ready) => ready === true,
       () => {
-        const feedState = sbot.db.getState().feeds[feedId]
+        const feedState = sbot.db.getState()[feedId]
 
         // this covers the case where you have a brand new feed
         if (!feedState) return cb(null, { id: null, sequence: 0 })
 
         return cb(null, {
-          id: feedState.id,
-          sequence: feedState.sequence
+          id: feedState.key,
+          sequence: feedState.value.sequence
         })
       }
     )

--- a/db.js
+++ b/db.js
@@ -495,6 +495,8 @@ exports.init = function (sbot, config) {
     registerIndex,
     setStateFeedsReady,
     loadStateFeeds,
+    stateFeedsReady,
+    getState: () => state,
     getIndexes: () => indexes,
     getIndex: (index) => indexes[index],
     clearIndexes,

--- a/test/feedstate.js
+++ b/test/feedstate.js
@@ -1,0 +1,39 @@
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const validate = require('ssb-validate')
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+
+const dir = '/tmp/ssb-db2-feedstate'
+
+rimraf.sync(dir)
+mkdirp.sync(dir)
+
+const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+
+const sbot = SecretStack({ appKey: caps.shs })
+  .use(require('../'))
+  .use(require('../compat/feedstate'))
+  .call(null, {
+    keys,
+    path: dir,
+  })
+const db = sbot.db
+
+test('Base', (t) => {
+  const post = { type: 'post', text: 'Testing!' }
+
+  db.publish(post, (err, postMsg) => {
+    t.error(err, 'no err')
+
+    sbot.getFeedState(keys.id, (err, state) => {
+      t.error(err)
+      t.equal(state.id, postMsg.key)
+      t.equal(state.sequence, postMsg.value.sequence)
+      sbot.close(t.end)
+    })
+  })
+})


### PR DESCRIPTION
Context: I'm interested in getting [ssb-crut](https://gitlab.com/ahau/ssb-crut) working with ssb-db2 so that we can use that for a building a library that implements the fusion identity spec.

I already have a branch that makes the library compatible with ssb-db2 I have been waiting with opening this PR until the validate2 branch was merged.