### PR TITLE
fix onceWhen self-remove logic 

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -7,20 +7,18 @@ function onceWhen(obv, filter, cb) {
   let answered = false
   let remove
   remove = obv((x) => {
+    if (answered) return
     if (!filter(x)) return
-    if (answered) {
-      if (remove) {
-        remove()
-        remove = null
-      }
-    } else {
-      answered = true
-      if (remove) {
-        remove()
-        remove = null
-      }
-      cb()
-    }
+
+    answered = true
+    cb()
+
+    if (!remove) return
+    setTimeout(() => {
+      if (!remove) return
+      remove()
+      remove = null
+    })
   })
 }
 


### PR DESCRIPTION
## Context

If you go to `ssb-meta-feeds-rpc` right now and run `npm it`, the test gets stuck. It's related to one of the these `onceWhen` not continuing.

## Problem

I think the underlying problem is in `obz`, as a concurrency bug when it loops through current listeners, but I spent some time trying to make a simple test and didn't manage to reproduce a clear error case. 

## Solution

On the other hand, `onceWhen` is written in a way that triggers the bug in `obz`, so we can rewrite `onceWhen` to not trigger the bug. The culprit is the `remove()` call, it synchronously messes up with the for-loop of current listeners. So we just schedule to run the `remove()` later. Anyway, the point of `remove()` is merely to avoid wasting computation. If we never `remove()`, the functionality would still be fine, because we have an `if (answered)` guard.

It's easier to make a new version of `ssb-db2` than it is to make a new version of `obz` because we don't want to update `obz` everywhere else (or get duplicates). Also, who knows if someone out there is depending on the buggy functionality of `obz`, and we would break their builds. So fixing `onceWhen` here is a safer option.