### PR TITLE
allow type() operator to be non-dedicated

### DIFF
--- a/operators/index.js
+++ b/operators/index.js
@@ -24,10 +24,17 @@ function key(msgId) {
   })
 }
 
-function type(value) {
-  return equal(seekType, value, {
-    indexType: 'value_content_type',
-  })
+function type(value, opts = { dedicated: true }) {
+  if (opts && opts.dedicated) {
+    return equal(seekType, value, {
+      indexType: 'value_content_type',
+    })
+  } else {
+    return equal(seekType, value, {
+      prefix: 32,
+      indexType: 'value_content_type',
+    })
+  }
 }
 
 // We don't need the author "prefix" to be an actual prefix, it can just be any
@@ -42,7 +49,7 @@ const AUTHOR_PREFIX_OFFSET = Math.max(
   'ssb:feed/bendybutt-v1/'.length
 )
 
-function author(value, opts) {
+function author(value, opts = { dedicated: false }) {
   if (opts && opts.dedicated) {
     return equal(seekAuthor, value, {
       indexType: 'value_author',


### PR DESCRIPTION
To solve issue https://github.com/ssb-ngi-pointer/ssb-meta-feeds-rpc/issues/9 in [ssb-meta-feeds-rpc](https://github.com/ssb-ngi-pointer/ssb-meta-feeds-rpc), we need to update [ssb-subset-ql](https://github.com/ssb-ngi-pointer/ssb-subset-ql) to use a non-dedicated index for `value_content_type`, and in turn that requires adding this functionality to ssb-db2.