### PR TITLE
fix UnhandledPromiseRejectionWarning on close()

### DIFF
--- a/db.js
+++ b/db.js
@@ -72,7 +72,7 @@ exports.init = function (sbot, config) {
   const state = {}
 
   sbot.close.hook(function (fn, args) {
-    close(() => {
+    close((err) => {
       fn.apply(this, args)
     })
   })
@@ -489,9 +489,9 @@ exports.init = function (sbot, config) {
       const index = indexes[indexName]
       tasks.push(promisify(index.close.bind(index))())
     }
-    return Promise.all(tasks)
+    Promise.all(tasks)
       .then(() => promisify(log.close)())
-      .then(cb)
+      .then(cb, cb)
   }
 
   // override query() from jitdb to implicitly call fromDB()


### PR DESCRIPTION
I sometimes got this kind of error, which seemed non-fatal but would cause the `sbot.close.hook` to not proceed:

```
(node:51671) UnhandledPromiseRejectionWarning: Error: async-flumelog: closed
    at async-append-only-log/index.js:308:36
    at async-append-only-log/index.js:341:69
    at Object.onDrain (async-append-only-log/index.js:317:12)
    at close (async-append-only-log/index.js:306:10)
    at async-append-only-log/index.js:317:12
    at promisify-4loc/index.js:3:11
    at new Promise (<anonymous>)
    at promisify-4loc/index.js:2:3
    at ssb-db2/db.js:494:39
(node:51671) UnhandledPromiseRejectionWarning: Unhandled promise rejection.
This error originated either by throwing inside of an async function 
without a catch block, or by rejecting a promise which was not handled with 
.catch(). To terminate the node process on unhandled promise rejection, use 
the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:51671) [DEP0018] DeprecationWarning: Unhandled promise rejections are 
deprecated. In the future, promise rejections that are not handled will 
terminate the Node.js process with a non-zero exit code.
```

The actual error comes from https://github.com/ssb-ngi-pointer/async-append-only-log/blob/fe09da77007b8aaffe05aa293fe07d83a97d2625/index.js#L307 which seems to be unnecessary (why is it sending an error when the log is closed?) but anyway, we should handle all errors, so this PR just adds an error handler. We don't "handle" the error in the hook, but at least subsequent `sbot.close.hook` are not blocked from proceeding.

An example of this error can be found at https://github.com/ssb-ngi-pointer/ssb-meta-feeds/pull/42/checks?check_run_id=3585762967