### PR TITLE
support opts.limit in createLogStream()

### DIFF
--- a/test/createLogStream.js
+++ b/test/createLogStream.js
@@ -107,6 +107,17 @@ test('createLogStream (live, !sync)', function (t) {
   })
 })
 
+test('createLogStream (limit)', function (t) {
+  pull(
+    sbot.createLogStream({ limit: 1 }),
+    pull.collect((err, ary) => {
+      t.error(err)
+      t.equal(ary.length, 1)
+      t.end()
+    })
+  )
+})
+
 // TODO
 test.skip('createLogStream (gt)', (t) => {
   const start = timestamp()


### PR DESCRIPTION
1st commit adds a failing test, 2nd commit fixes the test.

## Context

For netsim we need go-ssb, ssb-js with ssb-db, and ssb-js with ssb-db2 to behave similarly. 

## Problem

go-ssb and (js) ssb-db support the opts.limit arg in createLogStream, but ssb-db2 doesn't.

## Solution

Add opts.limit in createLogStream