### PR TITLE
add addTransction() functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,14 @@ without checking if the previous link is correct, otherwise normal
 validation. This makes it possible to use for partial replication to
 add all contact messages from a feed.
 
+### addTransaction(msgValues, oooMsgValues, cb)
+
+Similar to `addOOOBatch`, except you pass in an array of `msgValues`
+that will be validated in order and an array of `oooMsgValues` that
+will be validated similar to `addOOOBatch`. Finally all the messages
+are added to the database in such a way that either all of them are
+written to disc or none of them are.
+
 ### getStatus
 
 Gets the current db status, same functionality as

--- a/db.js
+++ b/db.js
@@ -42,6 +42,7 @@ exports.manifest = {
   publishAs: 'async',
   del: 'async',
   deleteFeed: 'async',
+  addTransaction: 'async',
   addOOO: 'async',
   addBatch: 'async',
   addOOOBatch: 'async',
@@ -189,6 +190,62 @@ exports.init = function (sbot, config) {
             log.add(keys[i], msgVals[i], done())
 
           done(cb)
+        })
+      }
+    )
+  }
+
+  function addTransaction(msgVals, oooMsgVals, cb) {
+    const guard = guardAgainstDuplicateLogs('addTransaction()')
+    if (guard) return cb(guard)
+
+    oooMsgVals = oooMsgVals || []
+    msgVals = msgVals || []
+
+    onceWhen(
+      stateFeedsReady,
+      (ready) => ready === true,
+      () => {
+        function add(msgKeys, oooKeys) {
+          log.addTransaction(
+            msgKeys.concat(oooKeys),
+            msgVals.concat(oooMsgVals),
+            (err, kvts) => {
+              if (err) return cb(err)
+
+              kvts.forEach((kvt) => post.set(kvt))
+              cb(null, kvts)
+            }
+          )
+        }
+
+        validate2.validateOOOBatch(hmacKey, oooMsgVals, (err, oooKeys) => {
+          if (msgVals.length === 0) add([], oooKeys)
+          else {
+            const author = msgVals[0].author
+            if (!Ref.isFeedId(author))
+              return cb(
+                new Error('addTransaction() does not support feed ID ' + author)
+              )
+
+            const latestMsgVal = state[author] ? state[author].value : null
+            validate2.validateBatch(
+              hmacKey,
+              msgVals,
+              latestMsgVal,
+              (err, msgKeys) => {
+                if (err) return cb(err)
+                else {
+                  const lastIndex = msgKeys.length - 1
+                  updateState({
+                    key: msgKeys[lastIndex],
+                    value: msgVals[lastIndex],
+                  })
+                  add(msgKeys, oooKeys)
+                }
+              }
+            )
+          }
         })
       }
     )
@@ -527,6 +584,7 @@ exports.init = function (sbot, config) {
     add,
     publish,
     publishAs,
+    addTransaction,
     addOOO,
     addOOOBatch,
     getStatus: () => status.obv,

--- a/log.js
+++ b/log.js
@@ -33,6 +33,28 @@ module.exports = function (dir, config, privateIndex) {
     })
   }
 
+  log.addTransaction = function (keys, values, cb) {
+    let buffers = []
+    let kvts = []
+
+    for (let i = 0; i < keys.length; ++i) {
+      const kvt = {
+        key: keys[i],
+        value: values[i],
+        timestamp: Date.now(),
+      }
+      const buf = Buffer.alloc(bipf.encodingLength(kvt))
+      bipf.encode(kvt, buf, 0)
+      buffers.push(buf)
+      kvts.push(kvt)
+    }
+
+    log.appendTransaction(buffers, (err) => {
+      if (err) cb(err)
+      else cb(null, kvts)
+    })
+  }
+
   // monkey-patch log.get to decrypt the msg
   const originalGet = log.get
   log.get = function (offset, cb) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "operators/*.js"
   ],
   "dependencies": {
-    "async-append-only-log": "^3.0.8",
+    "async-append-only-log": "^3.1.0",
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
     "bipf": "~1.5.0",


### PR DESCRIPTION
This exposes the recently added transaction support in AAOL. I thought it would be fine that this just worked on classic messages. We can always add bendy butt if needed. Similar to addBatch.