### PR TITLE
Add debug msg for bendy butt validation failure

### DIFF
--- a/db.js
+++ b/db.js
@@ -333,7 +333,12 @@ exports.init = function (sbot, config) {
         } else if (SSBURI.isBendyButtV1FeedSSBURI(msgVal.author)) {
           const previous = (state[msgVal.author] || { value: null }).value
           const err = bendyButt.validateSingle(msgVal, previous, hmacKey)
-          if (err) return cb(err)
+          if (err) {
+            debug(
+              `validation failed for bendy butt message in addImmediately(): ${err.message}`
+            )
+            return cb(err)
+          }
           const key = bendyButt.hash(msgVal)
           updateState({ key, value: msgVal })
           log.add(key, msgVal, (err, kvt) => {


### PR DESCRIPTION
Adds a `debug` message to `addImmediately()` to report when validation fails for a bendy butt message.

**Example output**

`2021-10-06T13:59:26.650Z ssb:db2 validation failed for bendy butt message in addImmediately(): invalid message: signature must correctly sign the payload`

**Question**

Do we want to add any additional `debug` message while I have this PR open?