### PR TITLE
Handle exceptions from box2 as err cb instead of throwing

### DIFF
--- a/db.js
+++ b/db.js
@@ -409,7 +409,13 @@ exports.init = function (sbot, config) {
       stateFeedsReady,
       (ready) => ready === true,
       () => {
-        if (content.recps) content = encryptContent(content)
+        if (content.recps) {
+          try {
+            content = encryptContent(content)
+          } catch (ex) {
+            return cb(ex)
+          }
+        }
         const latestKVT = state[keys.id]
         const msgVal = validate.create(
           latestKVT ? { queue: [latestKVT] } : null,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "secret-stack": "6.4.0",
     "ssb-caps": "1.1.0",
     "ssb-db": "19.3.1",
-    "ssb-db2-box2": "^0.2.0",
+    "ssb-db2-box2": "^0.3.2",
     "ssb-fixtures": "3.0.2",
     "ssb-friends": "5.1.0",
     "ssb-threads": "9.2.0",


### PR DESCRIPTION
I was testing a client with private groups and ran into an issue where own key was not provided. This together with latest ssb-db2-box2 provides a better error and I wanted to let that error show up in cb instead of having client handling the throw. With this merged tests on ssb-db2-box2 should [work again](https://github.com/ssb-ngi-pointer/ssb-db2-box2/runs/4115715159?check_suite_focus=true). 

Note the bump of ssb-db2-box2 is not strictly needed as we just use it for benchmarking, but thought it would be good to have that the latest version anyway.