### PR TITLE
Fix box2 classic encryption for publishAs

### DIFF
--- a/db.js
+++ b/db.js
@@ -315,10 +315,14 @@ exports.init = function (sbot, config) {
     )
   }
 
-  function encryptContent(content) {
+  function encryptContent(keys, content) {
     if (sbot.box2 && content.recps.every(sbot.box2.supportsBox2)) {
-      const feedState = state[config.keys.id]
-      return sbot.box2.encryptClassic(content, feedState ? feedState.key : null)
+      const feedState = state[keys.id]
+      return sbot.box2.encryptClassic(
+        keys,
+        content,
+        feedState ? feedState.key : null
+      )
     } else return ssbKeys.box(content, content.recps)
   }
 
@@ -411,7 +415,7 @@ exports.init = function (sbot, config) {
       () => {
         if (content.recps) {
           try {
-            content = encryptContent(content)
+            content = encryptContent(keys, content)
           } catch (ex) {
             return cb(ex)
           }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "secret-stack": "6.4.0",
     "ssb-caps": "1.1.0",
     "ssb-db": "19.3.1",
-    "ssb-db2-box2": "^0.3.2",
+    "ssb-db2-box2": "^0.5.0",
     "ssb-fixtures": "3.0.2",
     "ssb-friends": "5.1.0",
     "ssb-threads": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "async-append-only-log": "^3.1.0",
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
-    "bipf": "~1.5.0",
+    "bipf": "1.5.1",
     "debug": "~4.3.1",
     "fastintcompression": "0.0.4",
     "flumecodec": "0.0.1",


### PR DESCRIPTION
This is the problem I was experiencing with box2. Bendy butt was working fine, but not classic messages. The problem was the for classic messages we always used config.keys as the author, which doesn't work for metafeeds. So I had to change the api to make it work: https://github.com/ssb-ngi-pointer/ssb-db2-box2/commit/9c82d1909746327182511a0b8effd81de332ca3d. This PR uses the new api. With this change the tests will pass in ssb-db2-box2.