### PR TITLE
Fix canDecrypt when reindexing decrypted messages

### DIFF
--- a/indexes/private.js
+++ b/indexes/private.js
@@ -195,7 +195,7 @@ module.exports = function (dir, sbot, config) {
       if (!streaming) {
         // since we use bsb for canDecrypt we need to ensure recOffset
         // is inserted at the correct place when reindexing
-        var insertLocation = bsb.gt(canDecrypt, recOffset)
+        const insertLocation = bsb.gt(canDecrypt, recOffset)
         canDecrypt.splice(insertLocation, 0, recOffset)
       } else
         canDecrypt.push(recOffset)

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -192,20 +192,12 @@ module.exports = function (dir, sbot, config) {
       const content = tryDecryptContent(ciphertext, recBuffer, pValue)
       if (!content) return record
 
-      // since we use bsb for canDecrypt we need to ensure recOffset
-      // is inserted at the correct place when reindexing
-      let inserted = false
-      if (!streaming) { // reindexing
-        for (var i = 0; i < canDecrypt.length; ++i) {
-          if (canDecrypt[i] > recOffset) {
-            canDecrypt.splice(i, 0, recOffset)
-            inserted = true
-            break;
-          }
-        }
-      }
-
-      if (!inserted)
+      if (!streaming) {
+        // since we use bsb for canDecrypt we need to ensure recOffset
+        // is inserted at the correct place when reindexing
+        var insertLocation = bsb.gt(canDecrypt, recOffset)
+        canDecrypt.splice(insertLocation, 0, recOffset)
+      } else
         canDecrypt.push(recOffset)
 
       if (!streaming) saveIndexes(() => {})

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -192,7 +192,22 @@ module.exports = function (dir, sbot, config) {
       const content = tryDecryptContent(ciphertext, recBuffer, pValue)
       if (!content) return record
 
-      canDecrypt.push(recOffset)
+      // since we use bsb for canDecrypt we need to ensure recOffset
+      // is inserted at the correct place when reindexing
+      let inserted = false
+      if (!streaming) { // reindexing
+        for (var i = 0; i < canDecrypt.length; ++i) {
+          if (canDecrypt[i] > recOffset) {
+            canDecrypt.splice(i, 0, recOffset)
+            inserted = true
+            break;
+          }
+        }
+      }
+
+      if (!inserted)
+        canDecrypt.push(recOffset)
+
       if (!streaming) saveIndexes(() => {})
       return reconstructMessage(record, content)
     } else {


### PR DESCRIPTION
Testing box2 for real now with private groups and ran into this bug.

I'll be pushing up a new test in ssb-db2-box2 that shows the problem. There is probably also a fix in jitdb needed for that test to pass.