### PR TITLE
Work with latest jitdb bipf values change

### DIFF
--- a/operators/index.js
+++ b/operators/index.js
@@ -153,14 +153,13 @@ function authorIsBendyButtV1() {
 }
 
 function isRoot() {
-  return equal(seekRoot, null, {
+  return equal(seekRoot, undefined, {
     indexType: 'value_content_root',
   })
 }
 
-const B_TRUE = Buffer.alloc(1, 1)
 function isPrivate() {
-  return equal(seekPrivate, B_TRUE, { indexType: 'meta_private' })
+  return equal(seekPrivate, true, { indexType: 'meta_private' })
 }
 
 function isPublic() {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "async-append-only-log": "^3.1.0",
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
-    "bipf": "1.5.1",
+    "bipf": "^1.5.4",
     "debug": "~4.3.1",
     "fastintcompression": "0.0.4",
     "flumecodec": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "hoox": "0.0.1",
-    "jitdb": "^3.5.0",
+    "jitdb": "^4.0.0",
     "level": "^6.0.1",
     "level-codec": "^9.0.2",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
These are the changes needed to make this module work with the bipf changes in jitdb. Note this also unpins bipf. The changes are almost trivial and is a good way I think to show that the jitdb PR is a sound approach.

This is still a draft PR as it depends on the jitdb PR: https://github.com/ssb-ngi-pointer/jitdb/pull/182