### PR TITLE
Make sure processedOffset is only updated together with processedSeq

### DIFF
--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -96,15 +96,13 @@ module.exports = class Plugin {
 
       if (status && status.version === version) {
         processedSeq = status.processed
+        processedOffset = status.offset
+        this.offset.set(status.offset)
         if (this.onLoaded) {
           this.onLoaded(() => {
-            processedOffset = status.offset
-            this.offset.set(status.offset)
             this._stateLoaded.resolve()
           })
         } else {
-          processedOffset = status.offset
-          this.offset.set(status.offset)
           this._stateLoaded.resolve()
         }
       } else {

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -84,8 +84,8 @@ module.exports = class Plugin {
         if (record.value) this.processRecord(record, processedSeq)
         changes = this.batch.length
         processedSeq++
+        processedOffset = record.offset
       }
-      processedOffset = record.offset
 
       if (changes > chunkSize) this.flush(thenMaybeReportError)
       else if (isLive) liveFlush(thenMaybeReportError)


### PR DESCRIPTION
From https://github.com/ssb-ngi-pointer/ssb-db2/issues/291#issuecomment-998773451. I believe this should fix off-by-x bugs in level indexes. 

From that comment:

Look at this [line](https://github.com/ssb-ngi-pointer/ssb-db2/blob/86d502f0846c3c234f5f6ff47be3f5e4bbe58c20/indexes/plugin.js#L88) and imagine we have added a new plugin. In this case we will reindex, but most plugins will just [skip](https://github.com/ssb-ngi-pointer/ssb-db2/blob/86d502f0846c3c234f5f6ff47be3f5e4bbe58c20/indexes/plugin.js#L83). BUT they will update their `processedOffset` thus *lovering* it compared to `processedSeq`. If you then kill the app while some of them have updated, but *NOT* keys or base then there will be a mismatch!