### PR TITLE
add operators to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,3 +559,5 @@ Also exposes all [jitDB operators](https://github.com/ssb-ngi-pointer/jitdb#oper
 [ssb-friends]: https://github.com/ssbc/ssb-friends
 [ssb-search2]: https://github.com/staltz/ssb-search2
 [ssb-crut]: https://gitlab.com/ahau/lib/ssb-crut
+[operators]: https://github.com/ssb-ngi-pointer/ssb-db2/blob/master/operators/index.js
+[jitDB operators]: https://github.com/ssb-ngi-pointer/jitdb#operators

--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ sbot.db.query(
 )
 ```
 
+### operators
+
+See [operators/index.js](https://github.com/planetary-social/ssb-db2/blob/docs/operators/index.js)
+
+Also exposes all [jitDB operators](https://github.com/ssb-ngi-pointer/jitdb#operators)
+
+* type
+* author
+* channel
+* key
+* votesFor
+* contact
+* mentions
+* about
+* hasRoot
+* hasFork
+* hasBranch
+* authorIsBendyButtV1
+* isRoot
+* isPrivate
+* isPublic
+
+
 ### Leveldb plugins
 
 The queries you've seen above use JITDB, but there are some queries

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ sbot.db.query(
 
 ### operators
 
-See [operators/index.js](https://github.com/planetary-social/ssb-db2/blob/docs/operators/index.js)
+See [operators/index.js](https://github.com/ssb-ngi-pointer/ssb-db2/blob/master/operators/index.js)
 
 Also exposes all [jitDB operators](https://github.com/ssb-ngi-pointer/jitdb#operators)
 

--- a/README.md
+++ b/README.md
@@ -77,29 +77,6 @@ sbot.db.query(
 )
 ```
 
-### operators
-
-See [operators/index.js](https://github.com/ssb-ngi-pointer/ssb-db2/blob/master/operators/index.js)
-
-Also exposes all [jitDB operators](https://github.com/ssb-ngi-pointer/jitdb#operators)
-
-* type
-* author
-* channel
-* key
-* votesFor
-* contact
-* mentions
-* about
-* hasRoot
-* hasFork
-* hasBranch
-* authorIsBendyButtV1
-* isRoot
-* isPrivate
-* isPublic
-
-
 ### Leveldb plugins
 
 The queries you've seen above use JITDB, but there are some queries
@@ -395,6 +372,7 @@ automatically using `config.db2.automigrate` or manually like this:
 sbot.db2migrate.start()
 ```
 
+
 ## Methods
 
 ### get(msgId, cb)
@@ -544,6 +522,30 @@ const config = {
   }
 }
 ```
+
+### operators
+
+See [operators/index.js](https://github.com/ssb-ngi-pointer/ssb-db2/blob/master/operators/index.js)
+
+Also exposes all [jitDB operators](https://github.com/ssb-ngi-pointer/jitdb#operators)
+
+* type
+* author
+* channel
+* key
+* votesFor
+* contact
+* mentions
+* about
+* hasRoot
+* hasFork
+* hasBranch
+* authorIsBendyButtV1
+* isRoot
+* isPrivate
+* isPublic
+
+---------------------------------------------------------
 
 [ssb-db]: https://github.com/ssbc/ssb-db/
 [bipf]: https://github.com/ssbc/bipf/


### PR DESCRIPTION
This documents all operators added here for jitDB. It makes it easier to find them, but the drawback is that if the list of operators changes, there is one more place that needs to be changed (the documents).