### PR TITLE
when db is closed, dont call onDrain callbacks

### DIFF
--- a/db.js
+++ b/db.js
@@ -63,6 +63,7 @@ exports.manifest = {
 
 exports.init = function (sbot, config) {
   let self
+  let closed = false
   config = config || {}
   config.db2 = config.db2 || {}
   const indexes = {}
@@ -533,6 +534,7 @@ exports.init = function (sbot, config) {
     setTimeout(() => {
       onIndexesStateLoaded(() => {
         log.onDrain(() => {
+          if (closed) return
           const index = indexes[indexName]
           if (!index) return cb('Unknown index:' + indexName)
 
@@ -543,6 +545,7 @@ exports.init = function (sbot, config) {
             cb()
           } else {
             const remove = index.offset(() => {
+              if (closed) return
               if (index.offset.value === log.since.value) {
                 remove()
                 status.updateIndex(indexName, index.offset.value)
@@ -580,6 +583,9 @@ exports.init = function (sbot, config) {
     }
     Promise.all(tasks)
       .then(() => promisify(log.close)())
+      .then(() => {
+        closed = true
+      })
       .then(cb, cb)
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -38,6 +38,29 @@ let sbot = SecretStack({ appKey: caps.shs })
   })
 let db = sbot.db
 
+test('onDrain not called after db closed', (t) => {
+  sbot.close(() => {
+    t.pass('closed sbot')
+
+    db.onDrain(() => {
+      t.fail('onDrain called after db closed')
+    })
+
+    setTimeout(() => {
+      sbot = SecretStack({ appKey: caps.shs })
+        .use(require('../'))
+        .use(require('../compat/ebt'))
+        .call(null, {
+          keys,
+          path: dir,
+        })
+      db = sbot.db
+      t.pass('restarted sbot')
+      t.end()
+    }, 200)
+  })
+})
+
 test('Base', (t) => {
   const posts = []
   for (var i = 0; i < 30; ++i) posts.push({ type: 'post', text: 'Testing!' })
@@ -479,7 +502,7 @@ test('validate when latest loaded was private message', (t) => {
           })
         db = sbot.db
 
-        let normalPost = { type: 'post', text: 'Public stuff'}
+        let normalPost = { type: 'post', text: 'Public stuff' }
         db.publish(normalPost, (err, msg2) => {
           t.error(err, 'no err')
           t.equal(msg.key, msg2.value.previous)
@@ -487,29 +510,6 @@ test('validate when latest loaded was private message', (t) => {
         })
       })
     })
-  })
-})
-
-test('onDrain not called after db closed', (t) => {
-  sbot.close(() => {
-    t.pass('closed sbot')
-
-    db.onDrain(() => {
-      t.fail('onDrain called after db closed')
-    })
-
-    setTimeout(() => {
-      sbot = SecretStack({ appKey: caps.shs })
-        .use(require('../'))
-        .use(require('../compat/ebt'))
-        .call(null, {
-          keys,
-          path: dir,
-        })
-      db = sbot.db
-      t.pass('restarted sbot')
-      t.end()
-    }, 200)
   })
 })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -490,6 +490,29 @@ test('validate when latest loaded was private message', (t) => {
   })
 })
 
+test('onDrain not called after db closed', (t) => {
+  sbot.close(() => {
+    t.pass('closed sbot')
+
+    db.onDrain(() => {
+      t.fail('onDrain called after db closed')
+    })
+
+    setTimeout(() => {
+      sbot = SecretStack({ appKey: caps.shs })
+        .use(require('../'))
+        .use(require('../compat/ebt'))
+        .call(null, {
+          keys,
+          path: dir,
+        })
+      db = sbot.db
+      t.pass('restarted sbot')
+      t.end()
+    }, 200)
+  })
+})
+
 test('publishAs classic', (t) => {
   const keys = ssbKeys.generate()
 


### PR DESCRIPTION
## Context

When Manyverse is closed, I notice an error from here: https://github.com/staltz/manyverse/blob/332deeec5dca6166dcb39207e7581190ed1d5367/src/backend/plugins/connUtils.ts#L38

This error is silent and there are no problems for users, but I figured it would be good to fix that error anyway.

## Problem

If `onDrain` is requested after the sbot (and ssb-db2) has been closed, we still seem to call the `cb`, even though the `cb` cannot and should not make use of any ssb-db2 APIs because the log is closed, indexes are closed, etc.

## Solution

Add a boolean variable `closed` and check that it's false whenever calling the `cb`.

1st :x:, 2nd :heavy_check_mark: 