### PR TITLE
replace EventEmitter with pull-notify

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -13,9 +13,7 @@ const caps = require('ssb-caps')
 const ssbKeys = require('ssb-keys')
 const multicb = require('multicb')
 const pull = require('pull-stream')
-const asyncFilter = require('pull-async-filter')
 const validate = require('ssb-validate')
-const fromEvent = require('pull-stream-util/from-event')
 const DeferredPromise = require('p-defer')
 const trammel = require('trammel')
 const sleep = require('util').promisify(setTimeout)
@@ -147,15 +145,15 @@ const randos = [
   ssbKeys.generate().id,
   ssbKeys.generate().id,
   ssbKeys.generate().id,
-  ssbKeys.generate().id
+  ssbKeys.generate().id,
 ]
 
 function shuffle(a) {
   for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
   }
-  return a;
+  return a
 }
 
 test('private', async (t) => {
@@ -181,7 +179,10 @@ test('private', async (t) => {
       if (err) t.fail(err)
 
       t.pass(`box duration: ${duration}ms`)
-      fs.appendFileSync(reportPath, `| add 1000 private box1 elements | ${duration}ms |\n`)
+      fs.appendFileSync(
+        reportPath,
+        `| add 1000 private box1 elements | ${duration}ms |\n`
+      )
 
       sbot.db.onDrain('base', () => {
         let startQuery = Date.now()
@@ -191,7 +192,10 @@ test('private', async (t) => {
           toCallback((err, results) => {
             const durationQuery = Date.now() - startQuery
             t.pass(`unbox first run duration: ${durationQuery}ms`)
-            fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements first run | ${durationQuery}ms |\n`)
+            fs.appendFileSync(
+              reportPath,
+              `| unbox 1000 private box1 elements first run | ${durationQuery}ms |\n`
+            )
 
             startQuery = Date.now()
 
@@ -200,7 +204,10 @@ test('private', async (t) => {
               toCallback((err, results) => {
                 const durationQuery2 = Date.now() - startQuery
                 t.pass(`unbox second run duration: ${durationQuery2}ms`)
-                fs.appendFileSync(reportPath, `| unbox 1000 private box1 elements second run | ${durationQuery2}ms |\n`)
+                fs.appendFileSync(
+                  reportPath,
+                  `| unbox 1000 private box1 elements second run | ${durationQuery2}ms |\n`
+                )
 
                 sbot.close(() => ended.resolve())
               })
@@ -222,8 +229,8 @@ test('private box2', async (t) => {
       keys: keys2,
       path: dirPrivate,
       box2: {
-        alwaysbox2: true
-      }
+        alwaysbox2: true,
+      },
     })
 
   const recps = [...randos, keys2.id]
@@ -251,7 +258,10 @@ test('private box2', async (t) => {
       if (err) t.fail(err)
 
       t.pass(`box duration: ${duration}ms`)
-      fs.appendFileSync(reportPath, `| add 1000 private box2 elements | ${duration}ms |\n`)
+      fs.appendFileSync(
+        reportPath,
+        `| add 1000 private box2 elements | ${duration}ms |\n`
+      )
 
       sbot.db.onDrain('base', () => {
         let startQuery = Date.now()
@@ -261,7 +271,10 @@ test('private box2', async (t) => {
           toCallback((err, results) => {
             const durationQuery = Date.now() - startQuery
             t.pass(`unbox duration first run: ${durationQuery}ms`)
-            fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements first run | ${durationQuery}ms |\n`)
+            fs.appendFileSync(
+              reportPath,
+              `| unbox 1000 private box2 elements first run | ${durationQuery}ms |\n`
+            )
 
             startQuery = Date.now()
 
@@ -270,7 +283,10 @@ test('private box2', async (t) => {
               toCallback((err, results) => {
                 const durationQuery2 = Date.now() - startQuery
                 t.pass(`unbox duration second run: ${durationQuery2}ms`)
-                fs.appendFileSync(reportPath, `| unbox 1000 private box2 elements second run | ${durationQuery2}ms |\n`)
+                fs.appendFileSync(
+                  reportPath,
+                  `| unbox 1000 private box2 elements second run | ${durationQuery2}ms |\n`
+                )
 
                 sbot.close(() => ended.resolve())
               })
@@ -307,7 +323,7 @@ test('migrate (+db1)', async (t) => {
   sbot.db2migrate.start()
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.filter((progress) => progress === 1),
     pull.take(1),
     pull.drain(async () => {
@@ -337,7 +353,7 @@ test('migrate (alone)', async (t) => {
   sbot.db2migrate.start()
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.filter((progress) => progress === 1),
     pull.take(1),
     pull.drain(async () => {
@@ -368,7 +384,7 @@ test('migrate (+db1 +db2)', async (t) => {
   sbot.db2migrate.start()
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.filter((progress) => progress === 1),
     pull.take(1),
     pull.drain(async () => {
@@ -398,7 +414,7 @@ test('migrate (+db2)', async (t) => {
   sbot.db2migrate.start()
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.filter((progress) => progress === 1),
     pull.take(1),
     pull.drain(async () => {
@@ -427,7 +443,7 @@ test('migrate continuation (+db2)', async (t) => {
   sbot.db2migrate.start()
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.filter((progress) => progress > 0.9),
     pull.take(1),
     pull.drain(async () => {
@@ -449,7 +465,7 @@ test('migrate continuation (+db2)', async (t) => {
       sbot.db2migrate.start()
 
       pull(
-        fromEvent('ssb:db2:migrate:progress', sbot),
+        sbot.db2migrate.progress(),
         pull.filter((progress) => progress === 1),
         pull.take(1),
         pull.drain(async () => {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "monotonic-timestamp": "0.0.9",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
-    "pull-async-filter": "^1.0.0",
     "secret-stack": "6.4.0",
     "ssb-caps": "1.1.0",
     "ssb-db": "19.3.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "prettier": "^2.1.2",
     "pretty-quick": "^3.1.0",
     "pull-async-filter": "^1.0.0",
-    "pull-stream-util": "0.1.2",
     "secret-stack": "6.4.0",
     "ssb-caps": "1.1.0",
     "ssb-db": "19.3.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "pull-cont": "^0.1.1",
     "pull-drain-gently": "^1.1.0",
     "pull-level": "^2.0.4",
+    "pull-notify": "^0.1.2",
     "pull-paramap": "^1.2.2",
     "pull-stream": "^3.6.14",
     "push-stream": "^11.0.0",

--- a/test/migration-alone.js
+++ b/test/migration-alone.js
@@ -12,7 +12,6 @@ const caps = require('ssb-caps')
 const generateFixture = require('ssb-fixtures')
 const fs = require('fs')
 const pull = require('pull-stream')
-const fromEvent = require('pull-stream-util/from-event')
 
 const dir = '/tmp/ssb-db2-migrate-alone'
 

--- a/test/migration-alone.js
+++ b/test/migration-alone.js
@@ -46,7 +46,7 @@ test('migrate (alone) moves msgs from old log to new log', (t) => {
   sbot.db2migrate.start()
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.filter((x) => x === 1),
     pull.take(1),
     pull.collect((err) => {

--- a/test/migration.js
+++ b/test/migration.js
@@ -51,7 +51,7 @@ test('migrate moves msgs from old log to new log', (t) => {
   sbot.db2migrate.start()
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.take(1),
     pull.collect((err, nums) => {
       t.error(err)
@@ -88,7 +88,7 @@ test('migrate moves msgs from ssb-db to new log', (t) => {
   sbot.db2migrate.start()
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.take(1),
     pull.collect((err, nums) => {
       t.error(err)
@@ -126,7 +126,7 @@ test('migrate keeps new log synced with ssb-db being updated', (t) => {
     })
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.filter((x) => x === 1),
     pull.take(1),
     pull.drain(() => {
@@ -199,7 +199,7 @@ test('refuses to db2.add() while old log exists', (t) => {
     .call(null, { keys, path: dir, db2: { automigrate: true } })
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.filter((x) => x === 1),
     pull.take(1),
     pull.drain(() => {
@@ -259,7 +259,7 @@ test('dangerouslyKillFlumeWhenMigrated and refusing db2.publish()', (t) => {
   })
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.filter((x) => x === 1),
     pull.take(1),
     pull.drain(() => {
@@ -299,7 +299,7 @@ test('migrate does nothing when there is no old log', (t) => {
   }, 1000)
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.drain(() => {
       t.fail('we are not supposed to get any migrate progress events')
     })
@@ -336,7 +336,7 @@ test('migrate fixes buffers in msg.value.content.nonce', (t) => {
   sbot.db2migrate.start()
 
   pull(
-    fromEvent('ssb:db2:migrate:progress', sbot),
+    sbot.db2migrate.progress(),
     pull.take(1),
     pull.collect((err, nums) => {
       t.error(err)

--- a/test/migration.js
+++ b/test/migration.js
@@ -12,7 +12,6 @@ const caps = require('ssb-caps')
 const generateFixture = require('ssb-fixtures')
 const fs = require('fs')
 const pull = require('pull-stream')
-const fromEvent = require('pull-stream-util/from-event')
 const { toCallback, and, where, isPrivate, type } = require('../operators')
 
 const dir = '/tmp/ssb-db2-migrate'


### PR DESCRIPTION
## Problem

Using EventEmitter for migrate "progress" events is heavy, see: https://github.com/ssb-ngi-pointer/ssb-db2/pull/201

## Solution

There is no real need for the stream of progress events to be on the `sbot` as a stringly-named event. We can use pull-notify instead, which should be more straight to the point and hopefully a bit lighter.

**Note** this is a breaking change and will cause ssb-db2 version 3.0.0 to be published.