### PR TITLE
adding support for indexing publicWebHosting on about messages

### DIFF
--- a/indexes/about-self.js
+++ b/indexes/about-self.js
@@ -82,6 +82,8 @@ module.exports = class AboutSelf extends Plugin {
       profile.image = content.image.link
     else if (typeof content.image === 'string') profile.image = content.image
 
+    if (content.publicWebHosting !== 'undefined')  profile.publicWebHosting = content.publicWebHosting
+    
     this.profiles[author] = profile
   }
 

--- a/test/about-self.js
+++ b/test/about-self.js
@@ -27,6 +27,39 @@ let sbot = SecretStack({ appKey: caps.shs })
   })
 const db = sbot.db
 
+test('set publicWebHosting to false', (t) => {
+  const about = { type: 'about', about: sbot.id, publicWebHosting: false}
+  
+  db.publish(about, (err, postMsg) => {
+    t.error(err, 'no err')
+
+    sbot.db.onDrain('aboutSelf', () => {
+      const profile = sbot.db.getIndex('aboutSelf').getProfile(sbot.id)
+      t.equal(profile.publicWebHosting, about.publicWebHosting) // should be false
+
+      t.end()
+    })
+  })
+})
+
+
+test('set publicWebHosting to true', (t) => {
+  const about = { type: 'about', about: sbot.id, publicWebHosting: true}
+  
+  db.publish(about, (err, postMsg) => {
+    t.error(err, 'no err')
+
+    sbot.db.onDrain('aboutSelf', () => {
+      const profile = sbot.db.getIndex('aboutSelf').getProfile(sbot.id)
+      t.equal(profile.publicWebHosting, about.publicWebHosting) // should be true
+
+      t.end()
+    })
+  })
+})
+
+
+
 test('get self assigned', (t) => {
   const about = { type: 'about', about: sbot.id, name: 'arj', image: '%blob' }
   const aboutOther = { type: 'about', about: '@other', name: 'staltz' }
@@ -102,6 +135,7 @@ test('get live profile', (t) => {
   })
 })
 
+
 test('should load about-self from disk', (t) => {
   sbot.close((err) => {
     t.error(err)
@@ -121,6 +155,8 @@ test('should load about-self from disk', (t) => {
     })
   })
 })
+
+
 
 test('teardown sbot', (t) => {
   sbot.close(() => t.end())


### PR DESCRIPTION
In order to run a viewer which respects publicWebHosting we need to have that field indexed in the about messages. This PR is pretty simple. If there is a publicWebHosting in the content it records the value, including if it's false. If it's not defined, it doesn't record it. 

This is needed so that https://github.com/planetary-social/planetary-pub can correctly not serve content where users have chosen not to have their content visible in a web viewer. 

This is my first PR for ssb-db2, so any feedback is welcome. I found some oddness with the order of the tests in about-self tests which were beyond me. These tests should cover the functionality added. 