### PR TITLE
Add startDecryptBox1 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,12 @@ const config = {
     dangerouslyKillFlumeWhenMigrated: false,
 
     /**
+     * Only try to decrypt box1 messages created before this date
+     * Default: null
+     */
+    startDecryptBox1: "2022-03-25",
+
+    /**
      * A debouncing interval (measured in milliseconds) to control how often
      * should messages given to `sbot.add` be flushed in batches.
      * Default: 250

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ const config = {
     dangerouslyKillFlumeWhenMigrated: false,
 
     /**
-     * Only try to decrypt box1 messages created before this date
+     * Only try to decrypt box1 messages created after this date
      * Default: null
      */
     startDecryptBox1: "2022-03-25",

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -23,9 +23,9 @@ module.exports = function (dir, sbot, config) {
   let encrypted = []
   let canDecrypt = []
 
-  let startDecryptBox1 = null
-  if (config.db2.startDecryptBox1)
-    startDecryptBox1 = new Date(config.db2.startDecryptBox1)
+  const startDecryptBox1 = config.db2.startDecryptBox1
+        ? new Date(config.db2.startDecryptBox1)
+        : null
 
   const debug = Debug('ssb:db2:private')
 


### PR DESCRIPTION
# Background

Decrypting box1 messages is quite heavy (I ran a local query here on a 1GB file, querying for all messages from a particular ID is 41 sec with decryption and 30 sec without). Especially for new users where out of roughly a million or so messages, more than 10% will be encrypted. For a new user joining the network they will never be able to decrypt these messages, so it would make sense to allow one to only start a certain time. Like from your first message. That was my first solution, but I realized that figuring out when the first message is from can be problematic. You might be reinstalling from a backup keys, or even if you have a database, just figuring out when the first message is from without building the indexing.

Instead I thought we could at least have a simple timestamp that one can provide that will tell the system from which point on it should start decrypting. The immediate use case for this would be a client where the user has generated a new key. We then know the time and can provide that to db2. Another use case would be something like a pub where you don't want to decrypting messages, so you set the time to 2100-01-01 or something.