### PR TITLE
prepare() should not wait for base index

### DIFF
--- a/db.js
+++ b/db.js
@@ -617,10 +617,10 @@ exports.init = function (sbot, config) {
   function prepare(operation, cb) {
     if (sbot.db2migrate) {
       sbot.db2migrate.synchronized((isSynced) => {
-        if (isSynced) onDrain(next)
+        if (isSynced) next()
       })
     } else {
-      onDrain(next)
+      next()
     }
 
     function next() {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "hoox": "0.0.1",
-    "jitdb": "^6.1.0",
+    "jitdb": "^6.1.1",
     "level": "^6.0.1",
     "level-codec": "^9.0.2",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
## Context

#320 

This is the final piece of the puzzle for stable progress bars in Manyverse, I tested these changes already in the app.

## Problem

`prepare()` is doing `onDrain()` which means we're waiting for the base (leveldb) index to be built *before* starting the JITDB prepare.

Not only is this unnecessary (JITDB prepare is entirely independent from base index), it would also cause a jump backwards in the progress calculations, because first the leveldb indexes would be built (progress bar going forwards), and then once done the status update for JITDB would appear at the start (progress bar going back).

## Solution

Don't do `onDrain()`.

I tried to write a test to catch this use case, but couldn't find a way.