### PR TITLE
calculate progress when log is empty

### DIFF
--- a/status.js
+++ b/status.js
@@ -38,6 +38,7 @@ module.exports = function Status(log, jitdb) {
 
   // Crunch stats numbers to produce one number for the "indexing" progress
   function calculateProgress() {
+    if (!stats.log || stats.log < 0) return 1
     const avgJITDBOffset = avgOffset(Object.values(stats.jit), stats)
     const offsets = Object.values(stats.indexes).concat(avgJITDBOffset)
     return avgPercent(offsets, stats)


### PR DESCRIPTION
**Problem:** when the log is empty, `stats.jit` is still considered at "100%" while all the leveldb indexes are considered at "0%", so averaging them would give something like "10%" stuck.

**Solution:** if the log is empty, just return 100% progress.