### PR TITLE
force flush after reindexEncrypted is done

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "secret-stack": "6.4.0",
     "ssb-caps": "1.1.0",
     "ssb-db": "19.3.1",
-    "ssb-db2-box2": "^0.5.0",
+    "ssb-db2-box2": "^0.6.0",
     "ssb-fixtures": "3.0.4",
     "ssb-friends": "5.1.0",
     "ssb-threads": "9.2.0",

--- a/test/reindex-encrypted.js
+++ b/test/reindex-encrypted.js
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2021 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const pify = require('util').promisify
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+const pull = require('pull-stream')
+
+const { and, where, author, type, toPullStream } = require('../operators')
+const fullMentions = require('../operators/full-mentions')
+
+test('box2 group reindex larger', async (t) => {
+  const groupKey = Buffer.from(
+    '30720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
+    'hex'
+  )
+  const groupId = 'group1.8K-group'
+
+  const groupKey2 = Buffer.from(
+    '40720d8f9cbf37f6d7062826f6decac93e308060a8aaaa77e6a4747f40ee1a76',
+    'hex'
+  )
+  const groupId2 = 'group2.8K-group'
+
+  const dirAlice = '/tmp/ssb-db2-box2-group-reindex2-alice'
+  rimraf.sync(dirAlice)
+  mkdirp.sync(dirAlice)
+
+  const keysAlice = ssbKeys.loadOrCreateSync(path.join(dirAlice, 'secret'))
+
+  const alice = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .use(require('ssb-db2-box2'))
+    .call(null, {
+      keys: keysAlice,
+      path: dirAlice,
+    })
+
+  alice.box2.addGroupKey(groupId, groupKey)
+  alice.box2.addGroupKey(groupId2, groupKey2)
+  alice.box2.registerIsGroup((recp) => recp.endsWith('8K-group'))
+  alice.box2.setReady()
+
+  const dirBob = '/tmp/ssb-db2-box2-group-reindex2-bob'
+  rimraf.sync(dirBob)
+  mkdirp.sync(dirBob)
+
+  const keysBob = ssbKeys.loadOrCreateSync(path.join(dirBob, 'secret'))
+
+  const bob = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .use(require('../about-self'))
+    .use(require('../full-mentions'))
+    .use(require('ssb-db2-box2'))
+    .call(null, {
+      keys: keysBob,
+      path: dirBob,
+    })
+
+  bob.box2.registerIsGroup((recp) => recp.endsWith('8K-group'))
+  bob.box2.setReady()
+
+  let content0 = { type: 'about', text: 'not super secret1' }
+  let content1 = {
+    type: 'post',
+    text: 'super secret2',
+    mentions: [{ link: bob.id }],
+    recps: [groupId2],
+  }
+  let content2 = { type: 'wierd' }
+  let content3 = { type: 'about', text: 'super secret3', recps: [groupId] }
+  let content4 = { type: 'post', text: 'super secret4', recps: [groupId] }
+
+  const msg0 = await pify(alice.db.publish)(content0)
+  const msg1 = await pify(alice.db.publish)(content1)
+  const msg2 = await pify(alice.db.publish)(content2)
+  const msg3 = await pify(alice.db.publish)(content3)
+  const msg4 = await pify(alice.db.publish)(content4)
+
+  t.true(msg1.value.content.endsWith('.box2'), 'box2 encoded')
+  t.true(msg3.value.content.endsWith('.box2'), 'box2 encoded')
+  t.true(msg4.value.content.endsWith('.box2'), 'box2 encoded')
+
+  // first bob gets 2 messages, indexes those
+  await pify(bob.db.add)(msg0.value)
+  await pify(bob.db.add)(msg1.value)
+
+  await new Promise((resolve) => {
+    pull(
+      bob.db.query(where(and(author(alice.id), type('about'))), toPullStream()),
+      pull.collect((err, msgs) => {
+        t.equal(msgs.length, 1)
+        const msg = msgs[0]
+        t.equal(msg.value.content.text, 'not super secret1')
+        resolve()
+      })
+    )
+  })
+
+  // bob gets the rest
+  await pify(bob.db.add)(msg2.value)
+  await pify(bob.db.add)(msg3.value)
+  await pify(bob.db.add)(msg4.value)
+  bob.box2.addGroupKey(groupId, groupKey)
+
+  await pify(bob.db.reindexEncrypted)()
+
+  await new Promise((resolve) => {
+    pull(
+      bob.db.query(where(and(author(alice.id), type('post'))), toPullStream()),
+      pull.collect((err, msgs) => {
+        t.equal(msgs.length, 1)
+        const msg1 = msgs[0]
+        t.equal(msg1.value.content.text, 'super secret4')
+        resolve()
+      })
+    )
+  })
+
+  bob.box2.addGroupKey(groupId2, groupKey2)
+
+  // Bob doesn't get any results from a leveldb query on an encrypted msg
+  await new Promise((resolve) => {
+    pull(
+      bob.db.query(where(fullMentions(bob.id)), toPullStream()),
+      pull.collect((err, msgs) => {
+        t.equal(msgs.length, 0)
+        resolve()
+      })
+    )
+  })
+
+  await pify(bob.db.reindexEncrypted)()
+
+  await new Promise((resolve) => {
+    pull(
+      bob.db.query(where(and(author(alice.id), type('post'))), toPullStream()),
+      pull.collect((err, msgs) => {
+        t.equal(msgs.length, 2)
+        t.equal(msgs[0].value.content.text, 'super secret2')
+        t.equal(msgs[1].value.content.text, 'super secret4')
+        resolve()
+      })
+    )
+  })
+
+  // Bob get results from a leveldb query on an decrypted msg
+  await new Promise((resolve) => {
+    pull(
+      bob.db.query(where(fullMentions(bob.id)), toPullStream()),
+      pull.collect((err, msgs) => {
+        t.equal(msgs.length, 1)
+        t.equal(msgs[0].value.content.text, 'super secret2')
+        resolve()
+      })
+    )
+  })
+
+  await new Promise((resolve) => {
+    pull(
+      bob.db.query(where(and(author(alice.id), type('about'))), toPullStream()),
+      pull.collect((err, msgs) => {
+        t.equal(msgs.length, 2)
+        const msg1 = msgs[0]
+        t.equal(msg1.value.content.text, 'not super secret1')
+        const msg2 = msgs[1]
+        t.equal(msg2.value.content.text, 'super secret3')
+        resolve()
+      })
+    )
+  })
+
+  await Promise.all([pify(alice.close)(true), pify(bob.close)(true)])
+  t.end()
+})


### PR DESCRIPTION
## Context

Working on https://github.com/ssb-ngi-pointer/jitdb/issues/199

## Problem

There are no tests for reindexEncrypted in this repo, and as a result we were using the `processRecord` API incorrectly (not passing pValue arg), and even though we processed records on leveldb indexes, the changes were not persisted to disk.

## Solution

I copied the test from ssb-db2-box2, but tweaked it to make sure that we query a leveldb index before and after reindexEncrypted. Also, after reindexOffset is called for all leveldb indexes, force flush to disk. 

1st :x: 2nd :heavy_check_mark: 