### PR TITLE
improve performance of del() by 20x

### DIFF
--- a/db.js
+++ b/db.js
@@ -180,10 +180,10 @@ exports.init = function (sbot, config) {
   function getHelper(id, onlyValue, cb) {
     if (sbot.db2migrate) {
       sbot.db2migrate.synchronized((isSynced) => {
-        if (isSynced) onDrain(next)
+        if (isSynced) onDrain('keys', next)
       })
     } else {
-      onDrain(next)
+      onDrain('keys', next)
     }
 
     function next() {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "hoox": "0.0.1",
-    "jitdb": "^6.4.1",
+    "jitdb": "^6.5.0",
     "level": "^6.0.1",
     "level-codec": "^9.0.2",
     "lodash.debounce": "^4.0.8",

--- a/test/basic.js
+++ b/test/basic.js
@@ -123,7 +123,7 @@ test('get missing key', (t) => {
     t.error(err, 'no err')
 
     db.get('%fake', (err, getMsg) => {
-      t.equal(err.message, 'Key not found in database %fake')
+      t.equal(err.message, 'Msg %fake not found in leveldb index')
       t.end()
     })
   })

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 Anders Rune Jensen
+// SPDX-FileCopyrightText: 2021-2022 Anders Rune Jensen
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
@@ -26,4 +26,22 @@ function onceWhen(obv, filter, cb) {
   })
 }
 
-module.exports = { onceWhen }
+class ReadyGate {
+  constructor() {
+    this.waiting = []
+    this.ready = false
+  }
+
+  onReady(cb) {
+    if (this.ready) cb()
+    else this.waiting.push(cb)
+  }
+
+  setReady() {
+    this.ready = true
+    for (const cb of this.waiting) cb()
+    this.waiting = []
+  }
+}
+
+module.exports = { onceWhen, ReadyGate }


### PR DESCRIPTION
Uses `jitdb.lookup()` (see https://github.com/ssb-ngi-pointer/jitdb/issues/215) to improve the performance of `del()` and `getMsg()`.

See the numbers for `del()`:

## Before

|  | Duration |
|--|--|
| Publish 1000 messages | 359.185ms |
| Delete 500 messages | 1039.531ms |

## After

|  | Duration |
|--|--|
| Publish 1000 messages | 350.658ms |
| Delete 500 messages | 36.623ms |
| Wait for deletes to flush | 264.364ms |

Note that the flushing of deletes (264ms) is probably dominated by the duration of the [debounce period which is 250ms](https://github.com/ssb-ngi-pointer/async-append-only-log/blob/bec87f28c0f9a3e165fd36f98c8d3ba5622a40d4/index.js#L277).