### PR TITLE
update our usage of Obz to be safer

### DIFF
--- a/compat/ebt.js
+++ b/compat/ebt.js
@@ -19,7 +19,7 @@ exports.init = function (sbot, config) {
   sbot.getVectorClock = function getVectorClock(cb) {
     onceWhen(
       sbot.db2migrate && sbot.db2migrate.synchronized,
-      (isSynced) => isSynced,
+      (isSynced) => isSynced === true,
       () => {
         sbot.db.onDrain('base', () => {
           const clock = {}

--- a/db.js
+++ b/db.js
@@ -295,7 +295,7 @@ exports.init = function (sbot, config) {
               // prettier-ignore
               if (err) return cb(clarify(err, 'addTransaction() failed in the log'))
 
-              kvts.forEach((kvt) => post.set(kvt))
+              for (const kvt of kvts) post.set(kvt)
               cb(null, kvts)
             }
           )
@@ -558,7 +558,7 @@ exports.init = function (sbot, config) {
       write(record) {
         const buf = record.value
         const pValue = buf ? bipf.seekKey(buf, 0, B_VALUE) : -1
-        indexesArr.forEach((idx) => idx.onRecord(record, false, pValue))
+        for (const idx of indexesArr) idx.onRecord(record, false, pValue)
       },
       end() {
         debug(`updateIndexes() scan time: ${Date.now() - start}ms`)
@@ -572,7 +572,7 @@ exports.init = function (sbot, config) {
             write(record) {
               const buf = record.value
               const pValue = buf ? bipf.seekKey(buf, 0, B_VALUE) : -1
-              indexesArr.forEach((idx) => idx.onRecord(record, true, pValue))
+              for (const idx of indexesArr) idx.onRecord(record, true, pValue)
             },
           })
         })

--- a/migrate.js
+++ b/migrate.js
@@ -27,12 +27,6 @@ function fileExists(filename) {
   return fs.existsSync(filename) && fs.statSync(filename).size > 0
 }
 
-function makeFileExistsObv(filename) {
-  const obv = Obv()
-  obv.set(fileExists(filename))
-  return obv
-}
-
 // Forked from flumecodec because we have to support
 // bendy butt messages which may contain Buffers
 const jsonCodecForSSBFixtures = {
@@ -195,7 +189,7 @@ exports.manifest = {
 exports.init = function init(sbot, config) {
   config = config || {}
   config.db2 = config.db2 || {}
-  const oldLogExists = makeFileExistsObv(oldLogPath(config.path))
+  const oldLogExists = Obv().set(fileExists(oldLogPath(config.path)))
 
   /**
    * Boolean obv that indicates whether the new log is synced with the old log.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mkdirp": "^1.0.4",
     "multicb": "1.2.2",
     "mutexify": "^1.3.1",
-    "obz": "^1.0.3",
+    "obz": "^1.1.0",
     "p-defer": "^3.0.0",
     "promisify-4loc": "1.0.0",
     "pull-cat": "^1.1.11",

--- a/status.js
+++ b/status.js
@@ -11,8 +11,7 @@ module.exports = function Status(log, jitdb) {
     indexes: {},
     progress: 0,
   }
-  const obv = Obv()
-  obv.set(stats)
+  const obv = Obv().set(stats)
   const EMIT_INTERVAL = 1000
   let i = 0
   let iTimer = 0


### PR DESCRIPTION
This PR does 3 refactors.

I started by updating Obz to 1.1.0 to use the new `return false` style, but I noticed that actually our util `onceWhen` is safer (because if we were to use `return false` we have to run that as the last command, but in fact we need to unsubscribe from the Obz as soon as possible). So there are more things that use `onceWhen` now.

The other refactors are simple:

- replace `forEach()` with `for (const x of ..` because it's a bit better when debugging stack traces
- replace Promise.all with `multicb` where possible (because it's "quicker", promises add a microqueue task delay) 