### PR TITLE
add compact() API and auto-rebuild indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,16 +224,17 @@ sbot.db.getIndex('myindex').myOwnMethodToGetStuff()
 Or you can wrap that in a secret-stack plugin (in the example above,
 `exports.init` should return an object with the API functions).
 
-There are other special methods you can implement in order to add
-"hooks" in the `Plugin` subclass:
+There are other optional methods you can implement in the `Plugin` subclass:
 
-- `onLoaded(cb)`: called once, at startup, when the index is
-  successfully loaded from disk and is ready to receive queries
-- `onFlush(cb)`: called when the leveldb index is about to be saved to
+- `onLoaded(cb)`: a hook called once, at startup, when the index is successfully
+  loaded from disk and is ready to receive queries
+- `onFlush(cb)`: a hook called when the leveldb index is about to be saved to
   disk
-- `indexesContent()`: method used when reindexing private group
-  messages to determine if the leveldb index needs to be updated for
-  decrypted messages. The default method returns true.
+- `indexesContent()`: method used when reindexing private group messages to
+  determine if the leveldb index needs to be updated for decrypted messages. The
+  default method returns true.
+- `reset()`: a method that you can use to reset in-memory state that you might
+  have in your plugin, when the leveldb index is about to be rebuilt.
 
 ### Compatibility plugins
 
@@ -268,7 +269,7 @@ const sbot = SecretStack({ caps })
 The following is a list of modules that works well with ssb-db2:
 
  - [ssb-threads] for working with post messages as threads
- - [ssb-suggest-lite] for fetching profiles of authors 
+ - [ssb-suggest-lite] for fetching profiles of authors
  - [ssb-friends] for working with the social graph
  - [ssb-search2] for full-text searching
  - [ssb-crut] for working with records that can be modified
@@ -463,7 +464,7 @@ Use [JITDB's prepare](https://github.com/ssb-ngi-pointer/jitdb/#prepareoperation
 
 Waits for the index with name `indexName` to be in sync with the main
 log and then call `cb` with no arguments. If `indexName` is not
-provided, the base index will be used. 
+provided, the base index will be used.
 
 The reason we do it this way is that indexes are updated
 asynchronously in order to not block message writing.

--- a/README.md
+++ b/README.md
@@ -469,6 +469,11 @@ provided, the base index will be used.
 The reason we do it this way is that indexes are updated
 asynchronously in order to not block message writing.
 
+### compact(cb)
+
+Compacts the log (filling in the blanks left by deleted messages and optimizing
+space) and then rebuilds indexes.
+
 ## Configuration
 
 You can use ssb-config parameters to configure some aspects of ssb-db2:

--- a/db.js
+++ b/db.js
@@ -67,6 +67,7 @@ exports.manifest = {
   addBatch: 'async',
   addOOOBatch: 'async',
   getStatus: 'sync',
+  compact: 'async',
   indexingProgress: 'source',
 
   // `query` should be `sync`, but secret-stack is automagically converting it

--- a/db.js
+++ b/db.js
@@ -550,6 +550,14 @@ exports.init = function (sbot, config) {
     })
   }
 
+  function restartUpdateIndexes() {
+    if (abortLogStreamForIndexes) {
+      abortLogStreamForIndexes()
+      abortLogStreamForIndexes = null
+    }
+    indexesStateLoaded.onReady(updateIndexes)
+  }
+
   function registerIndex(Index) {
     const index = new Index(log, dir)
 
@@ -561,6 +569,7 @@ exports.init = function (sbot, config) {
   }
 
   function updateIndexes() {
+    if (!log.compactionProgress.value.done) return
     const start = Date.now()
 
     const indexesArr = Object.values(indexes)
@@ -828,6 +837,7 @@ exports.init = function (sbot, config) {
         rimraf.sync(resetLevelPath(dir))
         rimraf.sync(resetPrivatePath(dir))
         rimraf.sync(reindexJitPath(dir))
+        restartUpdateIndexes()
       }
     }
   })

--- a/defaults.js
+++ b/defaults.js
@@ -9,6 +9,12 @@ exports.flumePath = (dir) => path.join(dir, 'flume')
 exports.oldLogPath = (dir) => path.join(dir, 'flume', 'log.offset')
 exports.newLogPath = (dir) => path.join(dir, 'db2', 'log.bipf')
 exports.indexesPath = (dir) => path.join(dir, 'db2', 'indexes')
+exports.resetLevelPath = (dir) =>
+  path.join(dir, 'db2', 'post-compact-reset-level')
+exports.resetPrivatePath = (dir) =>
+  path.join(dir, 'db2', 'post-compact-reset-private')
+exports.reindexJitPath = (dir) =>
+  path.join(dir, 'db2', 'post-compact-reindex-jit')
 exports.jitIndexesPath = (dir) => path.join(dir, 'db2', 'jit')
 exports.tooHotOpts = (config) =>
   config.db2

--- a/indexes/about-self.js
+++ b/indexes/about-self.js
@@ -68,6 +68,10 @@ module.exports = class AboutSelf extends Plugin {
     return true
   }
 
+  reset() {
+    this.profiles = {}
+  }
+
   updateProfileData(author, content) {
     let profile = this.profiles[author] || {}
 

--- a/indexes/base.js
+++ b/indexes/base.js
@@ -64,6 +64,10 @@ module.exports = function makeBaseIndex(privateIndex) {
       this.privateIndex.saveIndexes(cb)
     }
 
+    reset() {
+      this.authorLatest.clear()
+    }
+
     // pull-stream where each item is { key, value }
     // where key is the authorId and value is { offset, sequence }
     getAllLatest() {

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -140,7 +140,9 @@ module.exports = class Plugin {
       }
     })
 
+    const subClassReset = this.reset
     this.reset = (cb) => {
+      if (subClassReset) subClassReset.call(this)
       this.level.clear(() => {
         processedSeq = 0
         processedOffset = -1

--- a/indexes/plugin.js
+++ b/indexes/plugin.js
@@ -139,6 +139,16 @@ module.exports = class Plugin {
         })
       }
     })
+
+    this.reset = (cb) => {
+      this.level.clear(() => {
+        processedSeq = 0
+        processedOffset = -1
+        this.batch = []
+        this.offset.set(-1)
+        cb()
+      })
+    }
   }
 
   get stateLoaded() {
@@ -158,10 +168,6 @@ module.exports = class Plugin {
   get valueEncoding() {
     if (encodings[this._valueEncoding]) return encodings[this._valueEncoding]
     else return undefined
-  }
-
-  remove(...args) {
-    this.level.clear(...args)
   }
 
   close(cb) {

--- a/indexes/private.js
+++ b/indexes/private.js
@@ -224,11 +224,19 @@ module.exports = function (dir, sbot, config) {
     return encrypted.filter((x) => !canDecryptSet.has(x))
   }
 
+  function reset(cb) {
+    encrypted = []
+    canDecrypt = []
+    latestOffset.set(-1)
+    saveIndexes(cb)
+  }
+
   return {
     latestOffset,
     decrypt,
     missingDecrypt,
     saveIndexes,
+    reset,
     stateLoaded: stateLoaded.promise,
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "mutexify": "^1.3.1",
     "obz": "^1.1.0",
     "p-defer": "^3.0.0",
-    "promisify-4loc": "1.0.0",
     "pull-cat": "^1.1.11",
     "pull-cont": "^0.1.1",
     "pull-drain-gently": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "operators/*.js"
   ],
   "dependencies": {
-    "async-append-only-log": "^4.2.1",
+    "async-append-only-log": "^4.2.2",
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "hoox": "0.0.1",
-    "jitdb": "ssb-ngi-pointer/jitdb#compact",
+    "jitdb": "^6.6.0",
     "level": "^6.0.1",
     "level-codec": "^9.0.2",
     "lodash.debounce": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "operators/*.js"
   ],
   "dependencies": {
-    "async-append-only-log": "^4.0.0",
+    "async-append-only-log": "^4.2.1",
     "atomic-file-rw": "^0.2.1",
     "binary-search-bounds": "^2.0.4",
     "bipf": "^1.5.4",
@@ -26,7 +26,7 @@
     "flumecodec": "0.0.1",
     "flumelog-offset": "3.4.4",
     "hoox": "0.0.1",
-    "jitdb": "^6.5.0",
+    "jitdb": "ssb-ngi-pointer/jitdb#compact",
     "level": "^6.0.1",
     "level-codec": "^9.0.2",
     "lodash.debounce": "^4.0.8",

--- a/test/compaction-resume.js
+++ b/test/compaction-resume.js
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2022 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const fs = require('fs')
+const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const pify = require('util').promisify
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+const {resetLevelPath, resetPrivatePath, reindexJitPath} = require('../defaults')
+
+const dir = '/tmp/ssb-db2-compaction-resume'
+
+rimraf.sync(dir)
+mkdirp.sync(dir)
+
+test('compaction resumes automatically after a crash', async (t) => {
+  t.timeoutAfter(20e3)
+
+  const keys = ssbKeys.loadOrCreateSync(path.join(dir, 'secret'))
+  let sbot = SecretStack({ appKey: caps.shs }).use(require('../')).call(null, {
+    keys,
+    path: dir,
+  })
+
+  const TOTAL = 1000
+  const msgKeys = []
+  for (let i = 0; i < TOTAL; i += 1) {
+    const msg = await pify(sbot.db.publish)({ type: 'post', text: `hi ${i}` })
+    msgKeys.push(msg.key)
+  }
+  t.pass('published messages')
+
+  await pify(sbot.db.onDrain)('keys')
+  const oldLogSize = sbot.db.getStatus().value.log
+
+  const keysIndex = sbot.db.getIndex('keys')
+  const seq3 = await pify(keysIndex.getSeq.bind(keysIndex))(msgKeys[3])
+  t.equals(seq3, 3, 'seq 3 for msg #3')
+
+  for (let i = 0; i < TOTAL; i += 2) {
+    await pify(sbot.db.del)(msgKeys[i])
+  }
+  t.pass('deleted messages')
+
+  await pify(sbot.close)(true)
+  t.pass('closed sbot')
+
+  fs.closeSync(fs.openSync(path.join(dir, 'db2', 'log.bipf.compaction'), 'w'))
+  fs.closeSync(fs.openSync(resetLevelPath(dir), 'w'))
+  fs.closeSync(fs.openSync(resetPrivatePath(dir), 'w'))
+  fs.closeSync(fs.openSync(reindexJitPath(dir), 'w'))
+  t.pass('pretend that compaction was in progress')
+
+  sbot = SecretStack({ appKey: caps.shs }).use(require('../')).call(null, {
+    keys,
+    path: dir,
+  })
+
+  let newLogSize = 0
+  let done = false
+  sbot.db.getStatus()((stats) => {
+    if (!stats.log) return
+    if (stats.log > oldLogSize * 0.6) return
+    if (newLogSize) return
+    if (stats.progress !== 1) return
+
+    newLogSize = stats.log
+    done = true
+  })
+
+  await new Promise((resolve) => {
+    const interval = setInterval(() => {
+      if (done) {
+        clearInterval(interval)
+        resolve()
+      }
+    }, 200)
+  })
+  t.pass('compaction started and ended automatically')
+
+  try {
+    const keysIndex2 = sbot.db.getIndex('keys')
+    const seq3after = await pify(keysIndex2.getSeq.bind(keysIndex2))(msgKeys[3])
+    t.equals(seq3after, 1, 'seq 1 for msg #3 after reindexing')
+  } catch (err) {
+    console.log(err)
+  }
+
+  t.notEquals(oldLogSize, 0, 'old log size is ' + oldLogSize)
+  t.notEquals(newLogSize, 0, 'new log size is ' + newLogSize)
+  t.true(newLogSize < oldLogSize * 0.6, 'at most 0.6x smaller')
+  t.true(newLogSize > oldLogSize * 0.4, 'at least 0.4x smaller')
+
+  await pify(sbot.close)(true)
+  t.end()
+})

--- a/test/compaction-resume.js
+++ b/test/compaction-resume.js
@@ -45,6 +45,7 @@ test('compaction resumes automatically after a crash', async (t) => {
   for (let i = 0; i < TOTAL; i += 2) {
     await pify(sbot.db.del)(msgKeys[i])
   }
+  await pify(sbot.db.getLog().onDeletesFlushed)()
   t.pass('deleted messages')
 
   await pify(sbot.close)(true)

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -53,6 +53,7 @@ test('compaction fills holes and reindexes', async (t) => {
     await pify(sbot.db.del)(msgKeys[i])
   }
   console.timeEnd('delete')
+  await pify(sbot.db.getLog().onDeletesFlushed)()
   t.pass('deleted messages')
 
   let newLogSize = 0

--- a/test/compaction.js
+++ b/test/compaction.js
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2022 Anders Rune Jensen
+//
+// SPDX-License-Identifier: Unlicense
+
+const test = require('tape')
+const ssbKeys = require('ssb-keys')
+const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
+const pify = require('util').promisify
+const SecretStack = require('secret-stack')
+const caps = require('ssb-caps')
+const { where, key, toCallback } = require('../operators')
+const { onceWhen } = require('../utils')
+
+test('compaction fills holes and reindexes', async (t) => {
+  t.timeoutAfter(20e3)
+
+  const dir = '/tmp/ssb-db2-compaction'
+
+  rimraf.sync(dir)
+  mkdirp.sync(dir)
+
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .call(null, {
+      keys: ssbKeys.loadOrCreateSync(path.join(dir, 'secret')),
+      path: dir,
+    })
+
+  const TOTAL = 1000
+  const msgKeys = []
+  console.time('publish')
+  for (let i = 0; i < TOTAL; i += 1) {
+    const msg = await pify(sbot.db.publish)({ type: 'post', text: `hi ${i}` })
+    msgKeys.push(msg.key)
+  }
+  t.pass('published messages')
+  console.timeEnd('publish')
+
+  await pify(sbot.db.onDrain)()
+  const oldLogSize = sbot.db.getStatus().value.log
+
+  const msg3 = await pify(sbot.db.getMsg)(msgKeys[3])
+  t.equals(msg3.value.content.text, 'hi 3')
+
+  const keysIndex = sbot.db.getIndex('keys')
+  const seq3 = await pify(keysIndex.getSeq.bind(keysIndex))(msgKeys[3])
+  t.equals(seq3, 3, 'seq 3 for msg #3')
+
+  console.time('delete')
+  for (let i = 0; i < TOTAL; i += 2) {
+    await pify(sbot.db.del)(msgKeys[i])
+  }
+  console.timeEnd('delete')
+  t.pass('deleted messages')
+
+  let newLogSize = 0
+  let done = false
+  sbot.db.getStatus()((stats) => {
+    if (!stats.log) return
+    if (stats.log > oldLogSize * 0.6) return
+    if (newLogSize) return
+    if (stats.progress !== 1) return
+
+    newLogSize = stats.log
+    console.timeEnd('reindex')
+    done = true
+  })
+
+  console.time('compact')
+  await pify(sbot.db.compact)()
+  console.timeEnd('compact')
+  console.time('reindex')
+
+  await new Promise((resolve) => {
+    const interval = setInterval(() => {
+      if (done) {
+        clearInterval(interval)
+        resolve()
+      }
+    }, 200)
+  })
+
+  const seq3after = await pify(keysIndex.getSeq.bind(keysIndex))(msgKeys[3])
+  t.equals(seq3after, 1, 'seq 1 for msg #3 after reindexing')
+
+  t.notEquals(oldLogSize, 0, 'old log size is ' + oldLogSize)
+  t.notEquals(newLogSize, 0, 'new log size is ' + newLogSize)
+  t.true(newLogSize < oldLogSize * 0.6, 'at most 0.6x smaller')
+  t.true(newLogSize > oldLogSize * 0.4, 'at least 0.4x smaller')
+
+  await pify(sbot.close)(true)
+  t.end()
+})
+
+test('queries are queued if compaction is in progress', async (t) => {
+  t.timeoutAfter(20e3)
+
+  const dir = '/tmp/ssb-db2-compaction2'
+
+  rimraf.sync(dir)
+  mkdirp.sync(dir)
+
+  const sbot = SecretStack({ appKey: caps.shs })
+    .use(require('../'))
+    .call(null, {
+      keys: ssbKeys.loadOrCreateSync(path.join(dir, 'secret')),
+      path: dir,
+    })
+
+  const TOTAL = 1000
+  const msgKeys = []
+  for (let i = 0; i < TOTAL; i += 1) {
+    const msg = await pify(sbot.db.publish)({ type: 'post', text: `hi ${i}` })
+    msgKeys.push(msg.key)
+  }
+  t.pass('published messages')
+
+  await pify(sbot.db.onDrain)()
+
+  for (let i = 0; i < TOTAL; i += 2) {
+    await pify(sbot.db.del)(msgKeys[i])
+  }
+  t.pass('deleted messages')
+
+  let compactDoneAt = 0
+  let queryDoneAt = 0
+  await new Promise((resolve) => {
+    sbot.db.compact((err) => {
+      t.error(err, 'no error')
+      compactDoneAt = Date.now()
+      if (queryDoneAt > 0) resolve()
+    })
+
+    onceWhen(
+      sbot.db.getLog().compactionProgress,
+      (stat) => stat.done === false,
+      () => {
+        sbot.db.query(
+          where(key(msgKeys[3])),
+          toCallback((err, msgs) => {
+            t.error(err, 'no error')
+            t.equals(msgs.length, 1)
+            t.equals(msgs[0].value.content.text, 'hi 3')
+            queryDoneAt = Date.now()
+            if (compactDoneAt > 0) resolve()
+          })
+        )
+      }
+    )
+  })
+  t.true(compactDoneAt < queryDoneAt, 'compaction done before query')
+
+  await pify(sbot.close)(true)
+  t.end()
+})


### PR DESCRIPTION
Context: https://github.com/ssb-ngi-pointer/ssb-db2/issues/306 and https://github.com/ssb-ngi-pointer/jitdb/issues/199

This PR adds the `compact()` ("async") API to ssb-db2 which just triggers async-append-only-log `compact()`. When it's done, it will rebuild all leveldb indexes from scratch, rebuild private indexes, and partially rebuild jitdb indexes. This is all done in a way that is crash-resistant, capable of resuming where it had stopped. And compaction is guaranteed to not happen concurrently with log.stream that builds indexes, or any jitdb query. 